### PR TITLE
Elementary archetype-based hierarchical clustering

### DIFF
--- a/src/entity_grouping.rs
+++ b/src/entity_grouping.rs
@@ -169,7 +169,7 @@ fn clustering_pass(clusters: &mut Vec<Cluster>) {
 }
 
 /// Finds the closest pair among the given `clusters`.
-fn find_closest_pair(clusters: &mut Vec<Cluster>) -> ClusterPairMetadata {
+fn find_closest_pair(clusters: &[Cluster]) -> ClusterPairMetadata {
     const EPSILON: f32 = 1e-5;
     let mut nearest_pair = ClusterPairMetadata {
         low: 0,


### PR DESCRIPTION
Implements `EntityGrouping::generate` using agglomerative clustering using Jaccard distance on archetype component sets. Each pass merges two clusters, so the `EntityGroup` ends up becoming a binary tree. I don't know whether the algorithm is stable under perturbations (i.e. structural resilience of the grouping to archetype changes).

## Limitations

One current limitation is the fact that if there are disjoint archetypes (i.e. no components in common), in the later stages only disjoint sets remain, all with distance `1.0` resulting in a tree where the initial branching has poor or no semantics. This might be fixed by stopping the algorithm when the nearest pair has distance `1.0`, adding all the remaining cluster entity groups as sub-groups of the `EntityGroup` to be returned.

Only leaf nodes contain entities. The root `EntityGroup` and the intermediate subgroups are empty. We might want to change this in the future: if an archetype is a perfect intersection of the parent group, it could be moved to the intermediate node instead of producing a leaf.

All components are treated equally, so expect common components like `Transform`, `GlobalTransform` and `Visibility` to be overrepresented. If this ends up being a problem, we might want to use weighted Jaccard instead, and assign a lower weight to engine components, or more simply, a configurable ignore list for certain components.

For `n` archetypes, this is a `O(n^3)` algorithm. We might want to consider some optimizations in the medium term if performance suffers in complex scenes. We might use bitsets instead of `HashSet` for faster set operations, or caching distances of cluster pairs in previous passes.