### PR TITLE
Use `warn!` on `Commands::inspect_component` failure

### DIFF
--- a/src/extension_methods.rs
+++ b/src/extension_methods.rs
@@ -429,7 +429,7 @@ impl EntityCommandsInspectionTrait for EntityCommands<'_> {
             let world = entity_world_mut.world();
             match world.inspect_component::<C>(entity, settings) {
                 Ok(inspection) => info!("{}", inspection),
-                Err(err) => info!("Failed to inspect component: {}", err),
+                Err(err) => warn!("Failed to inspect component: {}", err),
             }
         });
     }


### PR DESCRIPTION
Consistency with `Commands::inspect`.