### PR TITLE
Return `ComponentIdNotRegistered` in `inspect_component_by_id`

### DIFF
--- a/src/extension_methods.rs
+++ b/src/extension_methods.rs
@@ -245,7 +245,7 @@ impl WorldInspectionExtensionTrait for World {
         settings: ComponentInspectionSettings,
     ) -> Result<ComponentInspection, ComponentInspectionError> {
         let component_info = self.components().get_info(component_id).ok_or(
-            ComponentInspectionError::ComponentNotRegistered(type_name::<ComponentId>()),
+            ComponentInspectionError::ComponentIdNotRegistered(component_id),
         )?;
 
         if !self.entity(entity).contains_id(component_id) {


### PR DESCRIPTION
`inspect_component_by_id` has a guard that checks whether `component_id` is registered. However, the error variant returned in case of failure is wrong: `ComponentNotRegistered` instead of `ComponentIdNotRegistered`. This PR fixes that.

`ComponentNotRegistered` is already returned by `inspect_component`