### PR TITLE
Fix doc warnings

### DIFF
--- a/src/component_inspection.rs
+++ b/src/component_inspection.rs
@@ -16,7 +16,7 @@ use crate::memory_size::MemorySize;
 /// [`Debug`] can also be used for more detailed but harder to-read output.
 ///
 /// This should be paired with [`ComponentTypeMetadata`] to get full type information.
-/// [`ComponentTypeMetadata`] can be retrieved via [`World::get_component_type_metadata`],
+/// [`ComponentTypeMetadata`] can be retrieved via [`ComponentTypeMetadata::new`],
 /// and is relatively heavy to compute and store. You should cache it if inspecting many
 /// components of the same type.
 ///
@@ -186,6 +186,8 @@ impl Display for ComponentTypeMetadata {
 /// This is distinct from [`ComponentInspection`], which inspects a specific component on an entity.
 ///
 /// Call [`World::inspect_component_type`] to get this information.
+///
+/// [`World::inspect_component_type`]: crate::extension_methods::WorldInspectionExtensionTrait::inspect_component_type
 #[derive(Clone, Debug)]
 pub struct ComponentTypeInspection {
     /// The number of entities that have a component of this type.

--- a/src/entity_inspection.rs
+++ b/src/entity_inspection.rs
@@ -179,8 +179,6 @@ impl Default for MultipleEntityInspectionSettings {
 }
 
 /// Filters the provided entity list in-place according to the provided [`MultipleEntityInspectionSettings`].
-///
-/// Calls [`does_entity_match_filter_for_inspection`] for each entity.
 // PERF: this might be faster if you build a dynamic query instead of checking each entity individually.
 pub fn filter_entity_list_for_inspection(
     world: &World,

--- a/src/entity_name_resolution.rs
+++ b/src/entity_name_resolution.rs
@@ -18,11 +18,9 @@ use crate::entity_inspection::EntityInspection;
 impl EntityInspection {
     /// Determines the name to display for this entity.
     ///
-    /// If the [`Name`](bevy::prelude::Name) component is present, its value will be used.
+    /// If the [`Name`] component is present, its value will be used.
     ///
     /// If any component marked as "name-defining" is present, its name will be used.
-    /// This is done by implementing the [`NameDefining`] trait for the component type,
-    /// and then registering it for reflection by using the `#[reflect(NameDefining)]` attribute.
     /// If multiple name-defining components are present, they will be joined in alphabetical order,
     /// separated by a "|" character.
     ///

--- a/src/inspectable.rs
+++ b/src/inspectable.rs
@@ -1,7 +1,7 @@
 //! [`Inspectable`] trait to customize the inspection behavior of types.
 //!
 //! This module is heavily inspired by bevy-inspector-egui's
-//! [`InspectorOptions`](https://github.dev/jakobhellermann/bevy-inspector-egui/blob/main/crates/bevy-inspector-egui/examples/basic/inspector_options.rs
+//! [`InspectorOptions`](https://github.dev/jakobhellermann/bevy-inspector-egui/blob/main/crates/bevy-inspector-egui/examples/basic/inspector_options.rs)
 
 /// A trait used to customize the inspection behavior of types.
 ///

--- a/src/resource_inspection.rs
+++ b/src/resource_inspection.rs
@@ -28,7 +28,7 @@ pub struct ResourceInspection {
     pub type_id: Option<TypeId>,
     /// The size of the resource in memory.
     ///
-    /// This is computed using [`core::alloc::size_of_val`], and requires reflection of the resource value.
+    /// This is computed using [`core::mem::size_of_val`], and requires reflection of the resource value.
     pub memory_size: Option<MemorySize>,
     /// The type information of the resource.
     ///


### PR DESCRIPTION
Fixes doc warnings by following renames, removing references to private items from public docs, fixing syntax, and selecting the right `std::mem` module.