### PR TITLE
Control entity inspection settings case-sentivity with `NameFilter`

### DIFF
--- a/src/entity_inspection.rs
+++ b/src/entity_inspection.rs
@@ -181,7 +181,7 @@ impl Default for MultipleEntityInspectionSettings {
 /// A filter for named entities.
 ///
 /// For convenience, the [`From`] trait has been implemented
-/// for converting from [`String`], [`&String`] and [`&str`],
+/// for converting from [`String`], `&String` and [`&str`],
 /// so you can construct using `NameFilter::from("name")`.
 /// Keep in mind that in this case the matches will be case-insensitive.
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
This PR adds the ability to control whether entity inspection `MultipleEntityInspectionSettings::name_filter` is case-sensitive or not. The field now wraps `NameFilter`, which holds both the search query and the case-sensitivity flag. It also provides a `matches` method for easily checking a `Name`.

**Note:** This changes from obligatory case-sensitive to case-insensitive by default. This is better IMO, because it is a well established default in almost every UI across many different use-cases.