### PR TITLE
Relax trait bounds for grouping functions

### DIFF
--- a/src/archetype_similarity_grouping.rs
+++ b/src/archetype_similarity_grouping.rs
@@ -8,10 +8,7 @@ use bevy::{
 
 use crate::entity_grouping::EntityGrouping;
 
-pub(crate) fn group(
-    world: &World,
-    entities: impl ExactSizeIterator<Item = Entity>,
-) -> EntityGrouping {
+pub(crate) fn group(world: &World, entities: impl IntoIterator<Item = Entity>) -> EntityGrouping {
     let entities_by_archetype = get_entities_by_archetype(world, entities);
     if entities_by_archetype.is_empty() {
         return EntityGrouping::new();
@@ -33,7 +30,7 @@ pub(crate) fn group(
 /// Associates archetypes to the entities belonging to them.
 fn get_entities_by_archetype(
     world: &World,
-    entities: impl ExactSizeIterator<Item = Entity>,
+    entities: impl IntoIterator<Item = Entity>,
 ) -> HashMap<ArchetypeId, Vec<Entity>> {
     let mut entities_by_archetype: HashMap<ArchetypeId, Vec<Entity>> = HashMap::default();
     for entity in entities {

--- a/src/entity_grouping.rs
+++ b/src/entity_grouping.rs
@@ -31,7 +31,7 @@ impl EntityGrouping {
     /// Generates an [`EntityGrouping`] based on the components of the provided entities.
     pub fn generate(
         world: &World,
-        entities: impl ExactSizeIterator<Item = Entity>,
+        entities: impl IntoIterator<Item = Entity>,
         strategy: GroupingStrategy,
     ) -> Self {
         match strategy {

--- a/src/extension_methods.rs
+++ b/src/extension_methods.rs
@@ -62,7 +62,7 @@ pub trait WorldInspectionExtensionTrait {
     /// you should clear or modify the `metadata_map` before calling this method.
     fn inspect_multiple(
         &self,
-        entities: impl ExactSizeIterator<Item = Entity>,
+        entities: impl IntoIterator<Item = Entity>,
         settings: MultipleEntityInspectionSettings,
         metadata_map: &mut ComponentMetadataMap,
     ) -> Vec<Result<EntityInspection, EntityInspectionError>>;
@@ -215,7 +215,7 @@ impl WorldInspectionExtensionTrait for World {
 
     fn inspect_multiple(
         &self,
-        entities: impl ExactSizeIterator<Item = Entity>,
+        entities: impl IntoIterator<Item = Entity>,
         settings: MultipleEntityInspectionSettings,
         metadata_map: &mut ComponentMetadataMap,
     ) -> Vec<Result<EntityInspection, EntityInspectionError>> {


### PR DESCRIPTION
This PR changes the trait bound for grouping functions from `ExactSizeIterator` to `IntoIterator`, which is a more generic trait, allowing the function to accept more inputs. There are no `.len()` or `is_empty()` methods directly offered, but they can be accessed by `collect` the iterator (which we already do in the functions).

I also changed it for `inspect_multiple` since it doesn't need the old trait anymore.