### PR TITLE
Add setting option for grouping strategy

### DIFF
--- a/src/entity_inspection.rs
+++ b/src/entity_inspection.rs
@@ -21,6 +21,7 @@ use crate::{
     component_inspection::{
         ComponentDetailLevel, ComponentInspection, ComponentInspectionSettings,
     },
+    entity_grouping::GroupingStrategy,
     entity_name_resolution::EntityName,
     memory_size::MemorySize,
 };
@@ -164,6 +165,8 @@ pub struct MultipleEntityInspectionSettings {
     /// By default, only component names are included to improve performance
     /// and improve readability when inspecting many entities at once.
     pub entity_settings: EntityInspectionSettings,
+    /// Specifies how entities should be grouped.
+    pub grouping_strategy: GroupingStrategy,
 }
 
 impl Default for MultipleEntityInspectionSettings {
@@ -179,6 +182,7 @@ impl Default for MultipleEntityInspectionSettings {
                 },
                 ..Default::default()
             },
+            grouping_strategy: GroupingStrategy::Hierarchy,
         }
     }
 }

--- a/src/extension_methods.rs
+++ b/src/extension_methods.rs
@@ -12,7 +12,7 @@ use crate::{
         ComponentInspectionSettings, ComponentMetadataMap, ComponentTypeInspection,
         ComponentTypeMetadata,
     },
-    entity_grouping::{EntityGrouping, GroupingStrategy},
+    entity_grouping::EntityGrouping,
     entity_inspection::{
         EntityInspection, EntityInspectionError, EntityInspectionSettings,
         MultipleEntityInspectionSettings, filter_entity_list_for_inspection,
@@ -223,7 +223,7 @@ impl WorldInspectionExtensionTrait for World {
             metadata_map.update(self);
 
             let entity_grouping =
-                EntityGrouping::generate(self, entities, GroupingStrategy::ArchetypeSimilarity);
+                EntityGrouping::generate(self, entities, settings.grouping_strategy);
             let mut entity_list = entity_grouping.flatten();
 
             filter_entity_list_for_inspection(self, &mut entity_list, &settings);


### PR DESCRIPTION
Adds a `MultipleEntityInspectionSettings` option to allow users to select the `GroupingStrategy` they prefer when inspecting multiple entities. I opted for hierarchical grouping in the `Default` implementation since it tends to be more expected in inspector scenarios.