### PR TITLE
Add BRP module and serde

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # Run cargo test
+  # Run cargo test --all-features
   test:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
       - name: Run cargo test
-        run: cargo test
+        run: cargo test --all-features
 
   # Run cargo clippy --all-targets --all-features -- -D warnings
   clippy_check:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,10 @@ name = "accesskit"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
+dependencies = [
+ "enumn",
+ "serde",
+]
 
 [[package]]
 name = "accesskit_consumer"
@@ -88,7 +92,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -166,6 +170,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "approx"
@@ -264,6 +274,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.2",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +362,7 @@ dependencies = [
  "bevy_derive",
  "bevy_ecs",
  "bevy_reflect",
+ "serde",
 ]
 
 [[package]]
@@ -787,6 +816,7 @@ dependencies = [
  "bevy_reflect",
  "derive_more",
  "log",
+ "serde",
  "smol_str",
  "thiserror 2.0.17",
 ]
@@ -843,6 +873,7 @@ dependencies = [
  "bevy_post_process",
  "bevy_ptr",
  "bevy_reflect",
+ "bevy_remote",
  "bevy_render",
  "bevy_scene",
  "bevy_shader",
@@ -952,6 +983,7 @@ dependencies = [
  "bytemuck",
  "derive_more",
  "hexasphere",
+ "serde",
  "thiserror 2.0.17",
  "tracing",
  "wgpu-types",
@@ -1032,7 +1064,7 @@ dependencies = [
  "critical-section",
  "foldhash 0.2.0",
  "futures-channel",
- "getrandom",
+ "getrandom 0.3.4",
  "hashbrown 0.16.0",
  "js-sys",
  "portable-atomic",
@@ -1120,6 +1152,31 @@ dependencies = [
  "quote",
  "syn",
  "uuid",
+]
+
+[[package]]
+name = "bevy_remote"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5e053684d1735e62d8e491cb68f5d9f7219edcb6528d1ac5fe179f24e5fe497"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "async-io",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_log",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_tasks",
+ "bevy_utils",
+ "http-body-util",
+ "hyper",
+ "serde",
+ "serde_json",
+ "smol-hyper",
 ]
 
 [[package]]
@@ -1313,6 +1370,7 @@ checksum = "18839182775f30d26f0f84d9de85d25361bb593c99517a80b64ede6cbaf41adc"
 dependencies = [
  "async-channel",
  "async-executor",
+ "async-io",
  "async-task",
  "atomic-waker",
  "bevy_platform",
@@ -1409,6 +1467,7 @@ dependencies = [
  "bevy_utils",
  "bevy_window",
  "derive_more",
+ "serde",
  "smallvec",
  "taffy",
  "thiserror 2.0.17",
@@ -1798,6 +1857,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,6 +2087,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,6 +2121,17 @@ name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "disqualified"
@@ -2099,6 +2207,17 @@ name = "encase_derive_impl"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1796db3d892515842ca2dfb11124c4bb4a9e58d9f2c5c1072e5bca1b2334507b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2182,8 +2301,11 @@ name = "feathers_inspector"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "serde",
+ "serde_json",
  "strsim",
  "thiserror 2.0.17",
+ "ureq",
 ]
 
 [[package]]
@@ -2286,6 +2408,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2327,6 +2458,17 @@ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.2",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -2605,6 +2747,175 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "image"
 version = "0.25.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2726,7 +3037,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "libc",
 ]
 
@@ -2837,6 +3148,12 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "litrs"
@@ -3084,6 +3401,12 @@ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
@@ -3515,6 +3838,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "piper"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3572,6 +3901,21 @@ checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pp-rs"
@@ -3686,7 +4030,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3787,6 +4131,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rodio"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3851,6 +4209,41 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -4031,6 +4424,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -4055,6 +4451,19 @@ dependencies = [
  "wayland-protocols-wlr",
  "wayland-scanner",
  "xkeysym",
+]
+
+[[package]]
+name = "smol-hyper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7428a49d323867702cd12b97b08a6b0104f39ec13b49117911f101271321bc1a"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "futures-io",
+ "hyper",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -4115,6 +4524,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "svg_fmt"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4140,6 +4555,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4236,6 +4662,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,6 +4718,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4274,6 +4741,15 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+dependencies = [
+ "pin-project-lite",
+]
 
 [[package]]
 name = "toml_datetime"
@@ -4486,12 +4962,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
+dependencies = [
+ "base64",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf-8",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "uuid"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -4535,6 +5073,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -4743,6 +5287,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5441,6 +5994,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5510,6 +6069,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeno"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5529,6 +6111,66 @@ name = "zerocopy-derive"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,18 @@ opt-level = 3
 
 [dependencies]
 bevy = { version = "0.17", features = ["track_location"] }
+serde = { version = "1.0", optional = true,  features = ["derive"] }
+serde_json = { version = "1.0", optional = true }
 strsim = "0.11.1"
 thiserror = "2.0.17"
+
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
+ureq = { version = "3.1.4", features = ["json"] }
+
+[features]
+default = []
+serde = ["dep:serde"]
+remote = ["serde", "dep:serde_json", "bevy/bevy_remote"]
 
 # These lints may be important signals about code quality, but normal Bevy code
 # commonly triggers them and the CI workflow treats them as errors, so we've
@@ -28,3 +38,11 @@ thiserror = "2.0.17"
 [lints.clippy]
 too_many_arguments = "allow"
 type_complexity = "allow"
+
+[[example]]
+name = "brp_client"
+required-features = ["remote"]
+
+[[example]]
+name = "brp_server"
+required-features = ["remote"]

--- a/examples/brp_client.rs
+++ b/examples/brp_client.rs
@@ -1,0 +1,289 @@
+//! Demonstrates how to inspect an out-of-process Bevy app
+//! by sending BRP requests to it.
+//!
+//! Run this example with the `remote` feature enabled:
+//! ```bash
+//! cargo run --example brp_client --features="remote"
+//! ```
+
+use bevy::prelude::*;
+use bevy::remote::BrpRequest;
+use bevy::remote::builtin_methods::{BRP_QUERY_METHOD, BrpQuery, BrpQueryFilter, BrpQueryParams};
+use bevy::remote::http::{DEFAULT_ADDR, DEFAULT_PORT};
+use feathers_inspector::brp;
+use feathers_inspector::component_inspection::{
+    ComponentDetailLevel, ComponentInspection, ComponentInspectionSettings, ComponentMetadataMap,
+    ComponentTypeInspection,
+};
+use feathers_inspector::entity_inspection::{
+    EntityInspection, EntityInspectionError, EntityInspectionSettings,
+    MultipleEntityInspectionSettings,
+};
+use feathers_inspector::resource_inspection::{ResourceInspection, ResourceInspectionSettings};
+use feathers_inspector::summary::{SummarySettings, WorldSummary};
+
+use crate::helper::{construct_request, post_request, query};
+
+const SPRITE_COMPONENT_NAME: &str = "bevy_sprite::sprite::Sprite";
+const AMBIENT_LIGHT_COMPONENT_NAME: &str = "bevy_light::ambient_light::AmbientLight";
+
+#[derive(Resource, Debug)]
+struct BrpUrl(String);
+
+impl Default for BrpUrl {
+    fn default() -> Self {
+        let host_part = format!("{DEFAULT_ADDR}:{DEFAULT_PORT}");
+        Self(format!("http://{host_part}/"))
+    }
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .init_resource::<BrpUrl>()
+        .add_systems(Startup, setup)
+        .add_systems(
+            Update,
+            (
+                inspect_all_entities_when_space_pressed,
+                inspect_specific_component_when_c_pressed,
+                inspect_resource_when_r_pressed,
+                inspect_all_resources_when_a_pressed,
+                inspect_sprite_component_type_when_m_pressed,
+                summarize_when_s_pressed,
+            ),
+        )
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2d);
+
+    let instructions = "\
+This is your client process, that connects to the Bevy app via BRP.
+You can use the keyboard buttons to send BRP requests.
+Output will be shown in the console.
+
+Press `Space` to inspect all entities
+Press 'C' to inspect the Sprite component on all Sprite entities
+Press 'R' to inspect the AmbientLight resource
+Press 'A' to inspect all resources
+Press 'M' to inspect the Sprite component type metadata
+Press 'S' to obtain summary statistics"
+        .to_string();
+
+    commands.spawn((
+        Text::new(instructions),
+        Node {
+            position_type: PositionType::Absolute,
+            top: px(12),
+            left: px(12),
+            ..default()
+        },
+    ));
+}
+
+fn inspect_all_entities_when_space_pressed(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    brp_url: Res<BrpUrl>,
+) {
+    if keyboard_input.just_pressed(KeyCode::Space) {
+        let query_params = BrpQueryParams {
+            data: BrpQuery::default(),
+            filter: BrpQueryFilter::default(),
+            strict: false,
+        };
+        let entities = query(query_params, &brp_url.0);
+        let request = BrpRequest {
+            jsonrpc: String::from("2.0"),
+            method: brp::component_metadata_map_generate::METHOD.to_string(),
+            id: None,
+            params: None,
+        };
+        let metadata_map = post_request::<ComponentMetadataMap>(request, &brp_url.0);
+        let settings = MultipleEntityInspectionSettings {
+            entity_settings: EntityInspectionSettings {
+                include_components: false,
+                ..default()
+            },
+            ..default()
+        };
+        let params = brp::inspect_multiple::Params {
+            entities: entities.into_iter().collect::<Vec<Entity>>(),
+            settings,
+            metadata_map,
+        };
+        let request = construct_request(brp::inspect_multiple::METHOD, params);
+        let inspections = post_request::<Vec<Result<EntityInspection, EntityInspectionError>>>(
+            request, &brp_url.0,
+        );
+
+        for result in inspections {
+            if let Ok(inspection) = result {
+                info!("{inspection}");
+            } else {
+                warn!("Could not inspect an entity")
+            }
+        }
+    }
+}
+
+fn inspect_specific_component_when_c_pressed(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    brp_url: Res<BrpUrl>,
+) {
+    if keyboard_input.just_pressed(KeyCode::KeyC) {
+        let query_params = BrpQueryParams {
+            data: BrpQuery::default(),
+            filter: BrpQueryFilter {
+                with: vec![SPRITE_COMPONENT_NAME.to_string()],
+                ..default()
+            },
+            strict: false,
+        };
+        let entities = query(query_params, &brp_url.0);
+        let settings = ComponentInspectionSettings {
+            detail_level: ComponentDetailLevel::Values,
+            full_type_names: true,
+        };
+        for entity in entities {
+            let params = brp::inspect_component::Params {
+                component_type: SPRITE_COMPONENT_NAME.to_string(),
+                entity,
+                settings,
+                metadata_map: None,
+            };
+            let request = construct_request(brp::inspect_component::METHOD, params);
+            let inspection = post_request::<ComponentInspection>(request, &brp_url.0);
+            info!("{inspection}");
+        }
+    }
+}
+
+fn inspect_resource_when_r_pressed(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    brp_url: Res<BrpUrl>,
+) {
+    if keyboard_input.just_pressed(KeyCode::KeyR) {
+        let settings = ResourceInspectionSettings {
+            full_type_names: true,
+        };
+        let params = brp::inspect_resource::Params {
+            component_type: AMBIENT_LIGHT_COMPONENT_NAME.to_string(),
+            settings,
+            metadata_map: None,
+        };
+        let request = construct_request(brp::inspect_resource::METHOD, params);
+        let inspection = post_request::<ResourceInspection>(request, &brp_url.0);
+        info!("{inspection}");
+    }
+}
+
+fn inspect_all_resources_when_a_pressed(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    brp_url: Res<BrpUrl>,
+) {
+    if keyboard_input.just_pressed(KeyCode::KeyA) {
+        let settings = ResourceInspectionSettings {
+            full_type_names: false,
+        };
+        let params = brp::inspect_all_resources::Params { settings };
+        let request = construct_request(brp::inspect_all_resources::METHOD, params);
+        let inspections = post_request::<Vec<ResourceInspection>>(request, &brp_url.0);
+        for inspection in inspections {
+            info!("{inspection}");
+        }
+    }
+}
+
+fn inspect_sprite_component_type_when_m_pressed(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    brp_url: Res<BrpUrl>,
+) {
+    if keyboard_input.just_pressed(KeyCode::KeyM) {
+        let params = brp::inspect_component_type::Params {
+            component_type: SPRITE_COMPONENT_NAME.to_string(),
+            metadata_map: None,
+        };
+        let request = construct_request(brp::inspect_component_type::METHOD, params);
+        let inspection = post_request::<ComponentTypeInspection>(request, &brp_url.0);
+        info!("{inspection}");
+    }
+}
+
+fn summarize_when_s_pressed(keyboard_input: Res<ButtonInput<KeyCode>>, brp_url: Res<BrpUrl>) {
+    if keyboard_input.just_pressed(KeyCode::KeyS) {
+        let settings = SummarySettings::default();
+        let params = brp::summarize::Params { settings };
+        let request = construct_request(brp::summarize::METHOD, params);
+        let summary = post_request::<WorldSummary>(request, &brp_url.0);
+        info!("{summary}");
+    }
+}
+
+// Since BRP request and response handling are quite verbose,
+// we define a helper module to contain the complexity.
+mod helper {
+    use serde::{Serialize, de::DeserializeOwned};
+
+    use super::*;
+
+    pub fn query(params: BrpQueryParams, url: &str) -> Vec<Entity> {
+        let query_entities_request = BrpRequest {
+            jsonrpc: String::from("2.0"),
+            method: String::from(BRP_QUERY_METHOD),
+            id: None,
+            params: Some(
+                serde_json::to_value(params)
+                    .expect("Unable to convert query parameters to a valid JSON value"),
+            ),
+        };
+        let response = ureq::post(url)
+            .send_json(query_entities_request)
+            .expect("Failed to send JSON to server")
+            .body_mut()
+            .read_json::<serde_json::Value>()
+            .expect("Failed to read JSON response");
+        response["result"]
+            .as_array()
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|item| item["entity"].as_u64())
+                    .map(Entity::from_bits)
+                    .collect::<Vec<Entity>>()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn construct_request<T>(method: &str, params: T) -> BrpRequest
+    where
+        T: Serialize,
+    {
+        BrpRequest {
+            jsonrpc: String::from("2.0"),
+            method: method.to_string(),
+            id: None,
+            params: Some(
+                serde_json::to_value(params)
+                    .expect("Unable to convert query parameters to a valid JSON value"),
+            ),
+        }
+    }
+
+    pub fn post_request<T>(request: BrpRequest, url: &str) -> T
+    where
+        T: DeserializeOwned,
+    {
+        let response = ureq::post(url)
+            .send_json(request)
+            .expect("Failed to send JSON to server")
+            .body_mut()
+            .read_json::<serde_json::Value>()
+            .expect("Failed to read JSON response");
+        let result = response
+            .get("result")
+            .expect("Missing `result` field in JSON-RPC response");
+        serde_json::from_value::<T>(result.clone()).expect("Failed to deserialize")
+    }
+}

--- a/examples/brp_server.rs
+++ b/examples/brp_server.rs
@@ -1,0 +1,50 @@
+//! Demonstrates how to set up a BRP server
+//! with registered custom `feathers_inspector` methods on a Bevy app
+//! to allow out-of-process inspectors to inspect the Bevy app via BRP requests.
+//!
+//! Run this example with the `remote` feature enabled:
+//! ```bash
+//! cargo run --example brp_server --features="remote"
+//! ```
+
+use bevy::{
+    prelude::*,
+    remote::{RemotePlugin, http::RemoteHttpPlugin},
+};
+use feathers_inspector::{brp::InspectorBrpPlugin, entity_name_resolution::NameResolutionPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(NameResolutionPlugin)
+        .add_plugins((
+            RemotePlugin::default(),
+            RemoteHttpPlugin::default(),
+            InspectorBrpPlugin,
+        ))
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2d);
+    commands.spawn(Sprite {
+        image: asset_server.load("ducky.png"),
+        ..Default::default()
+    });
+
+    let instructions = "\
+This is your Bevy app, where the BRP server runs.
+Run the `brp_client` example on this machine to send BRP requests here."
+        .to_string();
+
+    commands.spawn((
+        Text::new(instructions),
+        Node {
+            position_type: PositionType::Absolute,
+            top: px(12),
+            left: px(12),
+            ..default()
+        },
+    ));
+}

--- a/src/brp/component_metadata_map_generate.rs
+++ b/src/brp/component_metadata_map_generate.rs
@@ -1,0 +1,24 @@
+//! Handles a `component_metadata_map.generate` request coming from a client.
+use bevy::{
+    prelude::*,
+    remote::{BrpError, BrpResult},
+};
+use serde_json::Value;
+
+use crate::component_inspection::ComponentMetadataMap;
+
+pub const METHOD: &str = "component_metadata_map.generate";
+
+pub(crate) struct VerbPlugin;
+
+impl Plugin for VerbPlugin {
+    fn build(&self, app: &mut App) {
+        let world = app.world_mut();
+        super::register_remote_method(world, METHOD, process_remote_request);
+    }
+}
+
+pub fn process_remote_request(In(_params): In<Option<Value>>, world: &World) -> BrpResult {
+    let metadata_map = ComponentMetadataMap::generate(world);
+    serde_json::to_value(metadata_map).map_err(BrpError::internal)
+}

--- a/src/brp/fuzzy_component_name_to_name.rs
+++ b/src/brp/fuzzy_component_name_to_name.rs
@@ -1,0 +1,50 @@
+//! Handles a `world.fuzzy_component_name_to_name` request coming from a client.
+use bevy::{
+    prelude::*,
+    remote::{BrpError, BrpResult},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    component_inspection::ComponentMetadataMap, fuzzy_name_mapping::fuzzy_component_name_to_id,
+};
+
+pub const METHOD: &str = "world.fuzzy_component_name_to_name";
+
+pub(crate) struct VerbPlugin;
+
+impl Plugin for VerbPlugin {
+    fn build(&self, app: &mut App) {
+        let world = app.world_mut();
+        super::register_remote_method(world, METHOD, process_remote_request);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Params {
+    pub fuzzy_name: String,
+    pub metadata_map: Option<ComponentMetadataMap>,
+}
+
+pub fn process_remote_request(In(params): In<Option<Value>>, world: &World) -> BrpResult {
+    let Params {
+        fuzzy_name,
+        metadata_map,
+    } = super::parse_some(params)?;
+    match fuzzy_component_name_to_id(world, &fuzzy_name) {
+        Some(component_id) => {
+            let metadata_map = metadata_map.unwrap_or(ComponentMetadataMap::generate(world));
+            let component_metadata = metadata_map.get(&component_id);
+            let Some(component_metadata) = component_metadata else {
+                let index = component_id.index();
+                return Err(BrpError::component_error(format!(
+                    "Could not find metadata for component `{index}`"
+                )));
+            };
+            Ok(serde_json::to_value(component_metadata.name.to_string())
+                .map_err(BrpError::internal)?)
+        }
+        None => Err(super::no_fuzzy_name_candidates_brp_error(&fuzzy_name)),
+    }
+}

--- a/src/brp/fuzzy_resource_name_to_name.rs
+++ b/src/brp/fuzzy_resource_name_to_name.rs
@@ -1,0 +1,50 @@
+//! Handles a `world.fuzzy_resource_name_to_name` request coming from a client.
+use bevy::{
+    prelude::*,
+    remote::{BrpError, BrpResult},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    component_inspection::ComponentMetadataMap, fuzzy_name_mapping::fuzzy_resource_name_to_id,
+};
+
+pub const METHOD: &str = "world.fuzzy_resource_name_to_name";
+
+pub(crate) struct VerbPlugin;
+
+impl Plugin for VerbPlugin {
+    fn build(&self, app: &mut App) {
+        let world = app.world_mut();
+        super::register_remote_method(world, METHOD, process_remote_request);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Params {
+    pub fuzzy_name: String,
+    pub metadata_map: Option<ComponentMetadataMap>,
+}
+
+pub fn process_remote_request(In(params): In<Option<Value>>, world: &World) -> BrpResult {
+    let Params {
+        fuzzy_name,
+        metadata_map,
+    } = super::parse_some(params)?;
+    match fuzzy_resource_name_to_id(world, &fuzzy_name) {
+        Some(component_id) => {
+            let metadata_map = metadata_map.unwrap_or(ComponentMetadataMap::generate(world));
+            let component_metadata = metadata_map.get(&component_id);
+            let Some(component_metadata) = component_metadata else {
+                let index = component_id.index();
+                return Err(BrpError::component_error(format!(
+                    "Could not find metadata for component `{index}`"
+                )));
+            };
+            Ok(serde_json::to_value(component_metadata.name.to_string())
+                .map_err(BrpError::internal)?)
+        }
+        None => Err(super::no_fuzzy_name_candidates_brp_error(&fuzzy_name)),
+    }
+}

--- a/src/brp/inspect.rs
+++ b/src/brp/inspect.rs
@@ -1,0 +1,40 @@
+//! Handles a `world.inspect` request coming from a client.
+use bevy::{
+    prelude::*,
+    remote::{BrpError, BrpResult},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    brp::inspect_cached::determine_error, entity_inspection::EntityInspectionSettings,
+    extension_methods::WorldInspectionExtensionTrait,
+};
+
+pub const METHOD: &str = "world.inspect";
+
+pub(crate) struct VerbPlugin;
+
+impl Plugin for VerbPlugin {
+    fn build(&self, app: &mut App) {
+        let world = app.world_mut();
+        super::register_remote_method(world, METHOD, process_remote_request);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Params {
+    pub entity: Entity,
+    pub settings: EntityInspectionSettings,
+}
+
+pub fn process_remote_request(In(params): In<Option<Value>>, world: &World) -> BrpResult {
+    let Params { entity, settings } = super::parse_some(params)?;
+    let entity_inspection = world.inspect(entity, settings);
+    match entity_inspection {
+        Ok(entity_inspection) => {
+            serde_json::to_value(entity_inspection).map_err(BrpError::internal)
+        }
+        Err(inspection_error) => Err(determine_error(entity, inspection_error)),
+    }
+}

--- a/src/brp/inspect_all_resources.rs
+++ b/src/brp/inspect_all_resources.rs
@@ -1,0 +1,34 @@
+//! Handles a `world.inspect_all_resources` request coming from a client.
+use bevy::{
+    prelude::*,
+    remote::{BrpError, BrpResult},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    extension_methods::WorldInspectionExtensionTrait,
+    resource_inspection::ResourceInspectionSettings,
+};
+
+pub const METHOD: &str = "world.inspect_all_resources";
+
+pub(crate) struct VerbPlugin;
+
+impl Plugin for VerbPlugin {
+    fn build(&self, app: &mut App) {
+        let world = app.world_mut();
+        super::register_remote_method(world, METHOD, process_remote_request);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Params {
+    pub settings: ResourceInspectionSettings,
+}
+
+pub fn process_remote_request(In(params): In<Option<Value>>, world: &World) -> BrpResult {
+    let Params { settings } = super::parse_some(params)?;
+    let inspection = world.inspect_all_resources(settings);
+    serde_json::to_value(inspection).map_err(BrpError::internal)
+}

--- a/src/brp/inspect_cached.rs
+++ b/src/brp/inspect_cached.rs
@@ -1,0 +1,63 @@
+//! Handles a `world.inspect_cached` request coming from a client.
+use bevy::{
+    prelude::*,
+    remote::{BrpError, BrpResult},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    component_inspection::ComponentMetadataMap,
+    entity_inspection::{EntityInspectionError, EntityInspectionSettings},
+    extension_methods::WorldInspectionExtensionTrait,
+};
+
+pub const METHOD: &str = "world.inspect_cached";
+
+pub(crate) struct VerbPlugin;
+
+impl Plugin for VerbPlugin {
+    fn build(&self, app: &mut App) {
+        let world = app.world_mut();
+        super::register_remote_method(world, METHOD, process_remote_request);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Params {
+    pub entity: Entity,
+    pub settings: EntityInspectionSettings,
+    pub metadata_map: ComponentMetadataMap,
+}
+
+pub fn process_remote_request(In(params): In<Option<Value>>, world: &World) -> BrpResult {
+    let Params {
+        entity,
+        settings,
+        metadata_map,
+    } = super::parse_some(params)?;
+    let entity_inspection = world.inspect_cached(entity, &settings, &metadata_map);
+    match entity_inspection {
+        Ok(entity_inspection) => {
+            serde_json::to_value(entity_inspection).map_err(BrpError::internal)
+        }
+        Err(inspection_error) => Err(determine_error(entity, inspection_error)),
+    }
+}
+
+pub(super) fn determine_error(entity: Entity, inspection_error: EntityInspectionError) -> BrpError {
+    use EntityInspectionError::*;
+    use bevy::ecs::query::QueryEntityError::*;
+    match inspection_error {
+        EntityNotFound(_) => BrpError::entity_not_found(entity),
+        UnexpectedQueryError(query_entity_error) => match query_entity_error {
+            QueryDoesNotMatch(_, _) => {
+                BrpError::internal("Reached invalid state: `QueryDoesNotMatch` on `SpawnDetails`")
+            }
+            EntityDoesNotExist(_) => BrpError::entity_not_found(entity),
+            AliasedMutability(_) => {
+                BrpError::internal("Reached invalid state: `AliasedMutability`")
+            }
+        },
+    }
+}

--- a/src/brp/inspect_component.rs
+++ b/src/brp/inspect_component.rs
@@ -1,0 +1,72 @@
+//! Handles a `world.inspect_component` request coming from a client.
+use bevy::{
+    prelude::*,
+    remote::{BrpError, BrpResult},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    component_inspection::{
+        ComponentInspectionError, ComponentInspectionSettings, ComponentMetadataMap,
+    },
+    extension_methods::WorldInspectionExtensionTrait,
+};
+
+pub const METHOD: &str = "world.inspect_component";
+
+pub(crate) struct VerbPlugin;
+
+impl Plugin for VerbPlugin {
+    fn build(&self, app: &mut App) {
+        let world = app.world_mut();
+        super::register_remote_method(world, METHOD, process_remote_request);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Params {
+    pub component_type: String,
+    pub entity: Entity,
+    pub settings: ComponentInspectionSettings,
+    pub metadata_map: Option<ComponentMetadataMap>,
+}
+
+pub fn process_remote_request(In(params): In<Option<Value>>, world: &World) -> BrpResult {
+    let Params {
+        component_type,
+        entity,
+        settings,
+        metadata_map,
+    } = super::parse_some(params)?;
+    let metadata_map = metadata_map.unwrap_or(ComponentMetadataMap::generate(world));
+    let Some((component_id, metadata)) =
+        super::component_type_to_metadata(&component_type, &metadata_map)
+    else {
+        return Err(super::component_type_not_in_metadata_brp_error(
+            &component_type,
+        ));
+    };
+    match world.inspect_component_by_id(component_id, entity, metadata, settings) {
+        Ok(inspection) => Ok(serde_json::to_value(inspection).map_err(BrpError::internal)?),
+        Err(error) => Err(determine_error(component_type, entity, error)),
+    }
+}
+
+fn determine_error(
+    component_type: String,
+    entity: Entity,
+    error: ComponentInspectionError,
+) -> BrpError {
+    match error {
+        ComponentInspectionError::ComponentNotFound(_) => {
+            BrpError::component_not_present(&component_type, entity)
+        }
+        ComponentInspectionError::ComponentNotRegistered(component_name) => {
+            BrpError::component_error(format!("Component not registered: `{component_name}`"))
+        }
+        ComponentInspectionError::ComponentIdNotRegistered(component_id) => {
+            BrpError::component_error(format!("Component id not registered: `{component_id:?}`"))
+        }
+    }
+}

--- a/src/brp/inspect_component_type.rs
+++ b/src/brp/inspect_component_type.rs
@@ -1,0 +1,64 @@
+//! Handles a `world.inspect_component_type` request coming from a client.
+use bevy::{
+    prelude::*,
+    remote::{BrpError, BrpResult},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    component_inspection::{ComponentInspectionError, ComponentMetadataMap},
+    extension_methods::WorldInspectionExtensionTrait,
+};
+
+pub const METHOD: &str = "world.inspect_component_type";
+
+pub(crate) struct VerbPlugin;
+
+impl Plugin for VerbPlugin {
+    fn build(&self, app: &mut App) {
+        let world = app.world_mut();
+        super::register_remote_method(world, METHOD, process_remote_request);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Params {
+    pub component_type: String,
+    pub metadata_map: Option<ComponentMetadataMap>,
+}
+
+pub fn process_remote_request(In(params): In<Option<Value>>, world: &World) -> BrpResult {
+    let Params {
+        component_type,
+        metadata_map,
+    } = super::parse_some(params)?;
+    let metadata_map = metadata_map.unwrap_or(ComponentMetadataMap::generate(world));
+    let Some((component_id, _)) = super::component_type_to_metadata(&component_type, &metadata_map)
+    else {
+        return Err(super::component_type_not_in_metadata_brp_error(
+            &component_type,
+        ));
+    };
+    match world.inspect_component_type_by_id(component_id) {
+        Ok(inspection) => Ok(serde_json::to_value(inspection).map_err(BrpError::internal)?),
+        Err(error) => Err(determine_error(error)),
+    }
+}
+
+fn determine_error(error: ComponentInspectionError) -> BrpError {
+    use ComponentInspectionError::*;
+    match error {
+        ComponentNotFound(component_id) => {
+            let component_index = component_id.index().to_string();
+            BrpError::component_error(format!("Component not found: {component_index}"))
+        }
+        ComponentNotRegistered(component_type_name) => {
+            BrpError::component_error(format!("Component not registered: {component_type_name}"))
+        }
+        ComponentIdNotRegistered(component_id) => {
+            let component_index = component_id.index().to_string();
+            BrpError::component_error(format!("Component not registered: {component_index}"))
+        }
+    }
+}

--- a/src/brp/inspect_multiple.rs
+++ b/src/brp/inspect_multiple.rs
@@ -1,0 +1,41 @@
+//! Handles a `world.inspect_multiple` request coming from a client.
+use bevy::{
+    prelude::*,
+    remote::{BrpError, BrpResult},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    component_inspection::ComponentMetadataMap,
+    entity_inspection::MultipleEntityInspectionSettings,
+    extension_methods::WorldInspectionExtensionTrait,
+};
+
+pub const METHOD: &str = "world.inspect_multiple";
+
+pub(crate) struct VerbPlugin;
+
+impl Plugin for VerbPlugin {
+    fn build(&self, app: &mut App) {
+        let world = app.world_mut();
+        super::register_remote_method(world, METHOD, process_remote_request);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Params {
+    pub entities: Vec<Entity>,
+    pub settings: MultipleEntityInspectionSettings,
+    pub metadata_map: ComponentMetadataMap,
+}
+
+pub fn process_remote_request(In(params): In<Option<Value>>, world: &World) -> BrpResult {
+    let Params {
+        entities,
+        settings,
+        mut metadata_map,
+    } = super::parse_some(params)?;
+    let inspection = world.inspect_multiple(entities, settings, &mut metadata_map);
+    serde_json::to_value(inspection).map_err(BrpError::internal)
+}

--- a/src/brp/inspect_resource.rs
+++ b/src/brp/inspect_resource.rs
@@ -1,0 +1,62 @@
+//! Handles a `world.inspect_resource` request coming from a client.
+use bevy::{
+    prelude::*,
+    remote::{BrpError, BrpResult},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    component_inspection::ComponentMetadataMap,
+    extension_methods::WorldInspectionExtensionTrait,
+    resource_inspection::{ResourceInspectionError, ResourceInspectionSettings},
+};
+
+pub const METHOD: &str = "world.inspect_resource";
+
+pub(crate) struct VerbPlugin;
+
+impl Plugin for VerbPlugin {
+    fn build(&self, app: &mut App) {
+        let world = app.world_mut();
+        super::register_remote_method(world, METHOD, process_remote_request);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Params {
+    pub component_type: String,
+    pub settings: ResourceInspectionSettings,
+    pub metadata_map: Option<ComponentMetadataMap>,
+}
+
+pub fn process_remote_request(In(params): In<Option<Value>>, world: &World) -> BrpResult {
+    let Params {
+        component_type,
+        settings,
+        metadata_map,
+    } = super::parse_some(params)?;
+    let metadata_map = metadata_map.unwrap_or(ComponentMetadataMap::generate(world));
+    let Some((component_id, _)) = super::component_type_to_metadata(&component_type, &metadata_map)
+    else {
+        return Err(super::component_type_not_in_metadata_brp_error(
+            &component_type,
+        ));
+    };
+    match world.inspect_resource_by_id(component_id, settings) {
+        Ok(inspection) => Ok(serde_json::to_value(inspection).map_err(BrpError::internal)?),
+        Err(error) => Err(determine_error(error)),
+    }
+}
+
+fn determine_error(error: ResourceInspectionError) -> BrpError {
+    use ResourceInspectionError::*;
+    match error {
+        ResourceNotRegistered(type_name) => {
+            BrpError::resource_error(format!("Resource not registered: {type_name}"))
+        }
+        ResourceNotFound(component_id) => {
+            BrpError::resource_not_present(&format!("Resource not found: {component_id:?}"))
+        }
+    }
+}

--- a/src/brp/mod.rs
+++ b/src/brp/mod.rs
@@ -1,0 +1,146 @@
+//! Provides a plugin that adds custom BRP verbs
+//! for methods defined in this library.
+//!
+//! To remotely use [`World`] methods
+//! and some other items defined in this crate,
+//! set up the BRP server in your Bevy app
+//! according to [`bevy::remote`]'s documentation.
+//! Then, register the custom methods by adding the [`InspectorBrpPlugin`].
+//! Now you can send inspector requests via BRP to your app and get a response.
+//!
+//! Refer to the submodules to learn more about specific handlers.
+
+use bevy::{
+    ecs::component::ComponentId,
+    prelude::*,
+    remote::{BrpError, BrpResult, RemoteMethodSystemId, RemoteMethods},
+};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::component_inspection::{ComponentMetadataMap, ComponentTypeMetadata};
+
+pub mod component_metadata_map_generate;
+pub mod fuzzy_component_name_to_name;
+pub mod fuzzy_resource_name_to_name;
+pub mod inspect;
+pub mod inspect_all_resources;
+pub mod inspect_cached;
+pub mod inspect_component;
+pub mod inspect_component_type;
+pub mod inspect_multiple;
+pub mod inspect_resource;
+pub mod summarize;
+
+/// Provides BRP verbs for calling functions and methods defined in this crate.
+///
+/// ## Panics
+///
+/// This plugin assumes [`RemotePlugin`] is already added,
+/// and will panic otherwise.
+///
+/// [`RemotePlugin`]: bevy::remote::RemotePlugin
+pub struct InspectorBrpPlugin;
+
+impl Plugin for InspectorBrpPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins((
+            component_metadata_map_generate::VerbPlugin,
+            fuzzy_component_name_to_name::VerbPlugin,
+            fuzzy_resource_name_to_name::VerbPlugin,
+            inspect::VerbPlugin,
+            inspect_all_resources::VerbPlugin,
+            inspect_cached::VerbPlugin,
+            inspect_component::VerbPlugin,
+            inspect_component_type::VerbPlugin,
+            inspect_multiple::VerbPlugin,
+            inspect_resource::VerbPlugin,
+            summarize::VerbPlugin,
+        ));
+    }
+}
+
+/// Registers an instant BRP method system under the given `method` name.
+///
+/// ## Panics
+///
+/// - If the [`RemotePlugin`] hasn't been added to the app
+///   (i.e., [`RemoteMethods`] resource is missing).
+///
+/// [`RemotePlugin`]: bevy::remote::RemotePlugin
+pub(crate) fn register_remote_method(
+    world: &mut World,
+    method: &str,
+    system: fn(bevy::prelude::In<Option<Value>>, &World) -> BrpResult,
+) {
+    let system_id = world.register_system(system);
+
+    let mut remote_methods = world
+        .get_resource_mut::<RemoteMethods>()
+        .expect("`RemotePlugin` must be present");
+    remote_methods.insert(method, RemoteMethodSystemId::Instant(system_id));
+}
+
+/// A helper function used to parse a `serde_json::Value`.
+// NOTE: This function was copied from the homonymous function in `bevy_remote::builtin_methods`.
+//       Remove once https://github.com/bevyengine/bevy/pull/22005 is merged and released.
+fn parse<T: for<'de> Deserialize<'de>>(value: Value) -> Result<T, BrpError> {
+    serde_json::from_value(value).map_err(|err| BrpError {
+        code: bevy::remote::error_codes::INVALID_PARAMS,
+        message: err.to_string(),
+        data: None,
+    })
+}
+
+/// A helper function used to parse a `serde_json::Value` wrapped in an `Option`.
+// NOTE: This function was copied from the homonymous function in `bevy_remote::builtin_methods`.
+//       Remove once https://github.com/bevyengine/bevy/pull/22005 is merged and released.
+fn parse_some<T: for<'de> Deserialize<'de>>(value: Option<Value>) -> Result<T, BrpError> {
+    match value {
+        Some(value) => parse(value),
+        None => Err(BrpError {
+            code: bevy::remote::error_codes::INVALID_PARAMS,
+            message: String::from("Params not provided"),
+            data: None,
+        }),
+    }
+}
+
+/// Returns a [`ComponentMetadataMap`] entry
+pub fn component_type_to_metadata<'metadata>(
+    component_type: &str,
+    metadata_map: &'metadata ComponentMetadataMap,
+) -> Option<(ComponentId, &'metadata ComponentTypeMetadata)> {
+    metadata_map.map.iter().find_map(|(id, meta)| {
+        let full = meta.name.to_string();
+        (full == component_type).then_some((*id, meta))
+    })
+}
+
+/// Custom BRP error codes for this library.
+pub mod error_codes {
+    /// Fuzzy name mapping returned no candidates.
+    pub const NO_FUZZY_NAME_CANDIDATES: i16 = 1;
+    /// The [`ComponentMetadataMap`] does not contain data about the given component.
+    ///
+    /// [`ComponentMetadataMap`]: crate::component_inspection::ComponentMetadataMap
+    pub const COMPONENT_TYPE_NOT_IN_METADATA: i16 = 2;
+}
+
+pub fn no_fuzzy_name_candidates_brp_error(fuzzy_name: &str) -> BrpError {
+    let data = serde_json::to_value(fuzzy_name.to_string()).ok();
+    BrpError {
+        code: error_codes::NO_FUZZY_NAME_CANDIDATES,
+        message: format!("No matches found for fuzzy name \"{fuzzy_name}\""),
+        data,
+    }
+}
+
+pub fn component_type_not_in_metadata_brp_error(component_type: &str) -> BrpError {
+    let data = serde_json::to_value(component_type.to_string()).ok();
+    BrpError {
+        code: error_codes::COMPONENT_TYPE_NOT_IN_METADATA,
+        message: format!("Component not found in metadata: `{component_type}`"),
+        data,
+    }
+}

--- a/src/brp/summarize.rs
+++ b/src/brp/summarize.rs
@@ -1,0 +1,31 @@
+//! Handles a `world.summarize` request coming from a client.
+use bevy::{
+    prelude::*,
+    remote::{BrpError, BrpResult},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::summary::{SummarySettings, WorldSummaryExt};
+
+pub const METHOD: &str = "world.summarize";
+
+pub(crate) struct VerbPlugin;
+
+impl Plugin for VerbPlugin {
+    fn build(&self, app: &mut App) {
+        let world = app.world_mut();
+        super::register_remote_method(world, METHOD, process_remote_request);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Params {
+    pub settings: SummarySettings,
+}
+
+pub fn process_remote_request(In(params): In<Option<Value>>, world: &World) -> BrpResult {
+    let Params { settings } = super::parse_some(params)?;
+    let summary = world.summarize(settings);
+    serde_json::to_value(summary).map_err(BrpError::internal)
+}

--- a/src/component_inspection.rs
+++ b/src/component_inspection.rs
@@ -22,14 +22,23 @@ use crate::memory_size::MemorySize;
 ///
 /// To inspect a component type itself, see [`ComponentTypeInspection`].
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ComponentInspection {
     /// The entity that owns the component.
     pub entity: Entity,
     /// The [`ComponentId`] of the component.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_conversions::component_id")
+    )]
     pub component_id: ComponentId,
     /// The type name of the component.
     ///
     /// This is duplicated from the metadata for convenience and [`Display`] printing.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_conversions::debug_name")
+    )]
     pub name: DebugName,
     /// The size, in bytes, of the component value.
     ///
@@ -82,17 +91,27 @@ impl Display for ComponentInspection {
 /// Instead, this type extracts all relevant information that can be stored and used later.
 ///
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ComponentTypeMetadata {
     /// The [`ComponentId`] of the component type.
     ///
     /// This is generally stored as a key in [`ComponentMetadataMap`],
     /// but is duplicated here for convenience.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_conversions::component_id")
+    )]
     pub component_id: ComponentId,
     /// The type name of the component.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_conversions::debug_name")
+    )]
     pub name: DebugName,
     /// The [`TypeId`] of the component type.
     ///
     /// Note that dynamic types will not have a [`TypeId`].
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub type_id: Option<TypeId>,
     /// The minimum size in bytes of the component type.
     ///
@@ -106,11 +125,19 @@ pub struct ComponentTypeMetadata {
     /// Returns true if the component type is mutable while in the ECS.
     pub mutable: bool,
     /// The storage type of this component.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_conversions::storage_type")
+    )]
     pub storage_type: StorageType,
     /// Returns true if the underlying component type can freely be shared across threads.
     pub is_send_and_sync: bool,
     /// The list of components required by this component,
     /// which will automatically be added when this component is added to an entity.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_conversions::slice_component_id")
+    )]
     pub required_components: Vec<ComponentId>,
     /// The type information of the component.
     ///
@@ -124,6 +151,7 @@ pub struct ComponentTypeMetadata {
     /// Note: this may be `None` if the type is not reflected and registered in the type registry.
     /// Currently, generic types need to be manually registered,
     /// and dynamically-typed components cannot be registered.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub type_registration: Option<TypeRegistration>,
 }
 
@@ -192,6 +220,7 @@ impl Display for ComponentTypeMetadata {
 ///
 /// [`World::inspect_component_type`]: crate::extension_methods::WorldInspectionExtensionTrait::inspect_component_type
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ComponentTypeInspection {
     /// The number of entities that have a component of this type.
     pub entity_count: usize,
@@ -217,7 +246,12 @@ impl Display for ComponentTypeInspection {
 /// This is useful for caching component metadata
 /// when inspecting multiple entities or components.
 #[derive(Clone, Debug, Deref, DerefMut)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ComponentMetadataMap {
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_conversions::hash_map_component_id_component_type_metadata")
+    )]
     pub map: HashMap<ComponentId, ComponentTypeMetadata>,
 }
 
@@ -288,20 +322,30 @@ impl FromWorld for ComponentMetadataMap {
 
 /// An error that can occur when attempting to inspect a component.
 #[derive(Debug, Error)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ComponentInspectionError {
     /// The component was not found on the entity.
     #[error("Component with ComponentId {0:?} not found on entity")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_conversions::component_id")
+    )]
     ComponentNotFound(ComponentId),
     /// The component type was not registered in the world.
     #[error("Component type {0} not registered in world")]
     ComponentNotRegistered(&'static str),
     /// The component ID provided was not registered in the world.
     #[error("ComponentId {0:?} not registered in world")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_conversions::component_id")
+    )]
     ComponentIdNotRegistered(ComponentId),
 }
 
 /// Settings for inspecting a component.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ComponentInspectionSettings {
     /// How much detail to include when inspecting component values.
     ///
@@ -322,6 +366,7 @@ pub struct ComponentInspectionSettings {
 /// so this setting allows users to limit the amount of information gathered
 /// when inspecting many entities or components at once.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ComponentDetailLevel {
     /// Only component type names are provided.
     Names,

--- a/src/entity_grouping.rs
+++ b/src/entity_grouping.rs
@@ -57,6 +57,7 @@ impl EntityGrouping {
 
 /// Specifies what kind of grouping [`EntityGrouping::generate`] should make.
 #[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GroupingStrategy {
     /// Group based on parent-child relationships.
     #[default]

--- a/src/entity_name_resolution.rs
+++ b/src/entity_name_resolution.rs
@@ -18,6 +18,7 @@ use crate::component_inspection::{ComponentInspection, ComponentTypeMetadata};
 ///
 /// This data is produced by [`resolve_name`].
 #[derive(Clone, Debug, PartialEq, Eq, Deref, DerefMut)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EntityName {
     #[deref]
     pub name: Name,
@@ -49,6 +50,7 @@ impl EntityName {
 /// Identifies whether the inspected entity's name
 /// is manually assigned or automatically resolved.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum NameOrigin {
     /// The entity name comes from the [`Name`] component.
     Custom,

--- a/src/extension_methods.rs
+++ b/src/extension_methods.rs
@@ -168,7 +168,7 @@ impl WorldInspectionExtensionTrait for World {
         // This unwrap is safe because `SpawnDetails` is always registered.
         let mut spawn_details_query = self.try_query::<SpawnDetails>().unwrap();
 
-        let spawn_details = spawn_details_query.get(self, entity)?;
+        let spawn_details = Some(spawn_details_query.get(self, entity)?);
 
         // Temporary binding to avoid dropping borrow
         let entity_ref = self.entity(entity);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,18 @@
 //! An experimental entity and world inspector for Bevy.
 //!
 //! Built using bevy_feathers, powered by bevy_reflect.
+//!
+//! ## Optional Cargo features
+//!
+//! - `serde`: Adds the `serde` crate
+//!   and implements `Serialize` and `Deserialize` on relevant types.
+//! - `remote`: Enables BRP server functionality.
+//!   Adds the `serde_json` crate,
+//!   and enables `serde` and `bevy/bevy_remote` features.
 
 pub mod archetype_similarity_grouping;
+#[cfg(feature = "remote")]
+pub mod brp;
 pub mod component_inspection;
 pub mod entity_grouping;
 pub mod entity_inspection;
@@ -14,4 +24,6 @@ pub mod inspectable;
 pub mod memory_size;
 pub mod reflection_tools;
 pub mod resource_inspection;
+#[cfg(feature = "serde")]
+pub mod serde_conversions;
 pub mod summary;

--- a/src/memory_size.rs
+++ b/src/memory_size.rs
@@ -4,6 +4,7 @@ use core::fmt::Display;
 
 /// The size of an object in memory, in bytes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MemorySize(pub usize);
 
 impl MemorySize {

--- a/src/resource_inspection.rs
+++ b/src/resource_inspection.rs
@@ -12,10 +12,19 @@ use thiserror::Error;
 /// Log this using the [`Display`] trait to see details about the resource.
 /// [`Debug`] can also be used for more detailed but harder to-read output.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResourceInspection {
     /// The [`ComponentId`] of the resource.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_conversions::component_id")
+    )]
     pub component_id: ComponentId,
     /// The type name of the resource.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_conversions::debug_name")
+    )]
     pub name: DebugName,
     /// The value of the resource as a string.
     ///
@@ -25,6 +34,7 @@ pub struct ResourceInspection {
     /// The [`TypeId`] of the resource.
     ///
     /// Note that dynamic types will not have a [`TypeId`].
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub type_id: Option<TypeId>,
     /// The size of the resource in memory.
     ///
@@ -42,6 +52,7 @@ pub struct ResourceInspection {
     /// Note: this may be `None` if the type is not reflected and registered in the type registry.
     /// Currently, generic types need to be manually registered,
     /// and dynamically-typed resources cannot be registered.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub type_registration: Option<TypeRegistration>,
 }
 
@@ -59,18 +70,24 @@ impl Display for ResourceInspection {
 
 /// An error that can occur when attempting to inspect a resource.
 #[derive(Debug, Error)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ResourceInspectionError {
     /// The resource type was not registered in the world.
     #[error("Resource type {0} not registered in world")]
     ResourceNotRegistered(&'static str),
     /// The resource was not found in the world.
     #[error("Resource with ComponentId {0:?} not found in world")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_conversions::component_id")
+    )]
     ResourceNotFound(ComponentId),
 }
 
 /// Settings that can be used to customize resource inspection,
 /// changing how [`ResourceInspection`] is generated and displayed.
 #[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResourceInspectionSettings {
     /// Whether or not full type names should be displayed.
     ///

--- a/src/serde_conversions.rs
+++ b/src/serde_conversions.rs
@@ -1,0 +1,276 @@
+//! Serde helper modules for value conversions.
+
+use bevy::ecs::{
+    entity::EntityDoesNotExistError,
+    query::{QueryEntityError, SpawnDetails},
+};
+use serde::Serialize;
+
+/// Serde helper module to serialize [`ComponentId`] as its underlying integer index.
+///
+/// ## Usage
+///
+/// Add `#[serde(with = "crate::serde_conversions::component_id")]`
+/// to the struct's [`ComponentId`] field.
+///
+/// [`ComponentId`]: bevy::ecs::component::ComponentId
+pub mod component_id {
+    use bevy::ecs::component::ComponentId;
+    use serde::{Deserialize, Serialize};
+
+    /// Serializes a [`ComponentId`] into its index.
+    pub fn serialize<S>(id: &ComponentId, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        id.index().serialize(serializer)
+    }
+
+    /// Deserializes the index of a [`ComponentId`].
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<ComponentId, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let index = usize::deserialize(deserializer)?;
+        Ok(ComponentId::new(index))
+    }
+}
+
+/// Serde helper module to serialize [`ArchetypeId`] as its underlying integer index.
+///
+/// ## Usage
+///
+/// Add `#[serde(with = "crate::serde_conversions::archetype_id")]`
+/// to the struct's [`ArchetypeId`] field.
+///
+/// [`ArchetypeId`]: bevy::ecs::archetype::ArchetypeId
+pub mod archetype_id {
+    use bevy::ecs::archetype::ArchetypeId;
+    use serde::{Deserialize, Serialize};
+
+    /// Serializes an [`ArchetypeId`] into its index.
+    pub fn serialize<S>(id: &ArchetypeId, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        id.index().serialize(serializer)
+    }
+
+    /// Deserializes the index of an [`ArchetypeId`].
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<ArchetypeId, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let index = usize::deserialize(deserializer)?;
+        Ok(ArchetypeId::new(index))
+    }
+}
+
+/// Serde helper module to serialize a slice of [`ComponentId`]s as a `Vec` of indexes.
+///
+/// ## Usage
+///
+/// Add `#[serde(with = "crate::serde_conversions::vec_component_id")]`
+/// to the struct's `Vec<ComponentId>` field.
+///
+/// [`ComponentId`]: bevy::ecs::component::ComponentId
+pub mod slice_component_id {
+    use bevy::ecs::component::ComponentId;
+    use serde::{Deserialize, ser::SerializeSeq};
+
+    /// Serializes a `Vec<[ComponentId]>` into a `Vec` of indexes.
+    pub fn serialize<S>(ids: &[ComponentId], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(ids.len()))?;
+        for id in ids {
+            seq.serialize_element(&id.index())?;
+        }
+        seq.end()
+    }
+
+    /// Deserializes a `Vec` of indexes to a  `Vec<[ComponentId]>`.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<ComponentId>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let indexes: Vec<usize> = Vec::deserialize(deserializer)?;
+        Ok(indexes.into_iter().map(ComponentId::new).collect())
+    }
+}
+
+/// Serde helper module to serialize [`DebugName`] as a string.
+///
+/// ## Usage
+///
+/// Add `#[serde(with = "crate::serde_conversions::debug_name")]`
+/// to the struct's [`DebugName`] field.
+///
+/// [`DebugName`]: bevy::utils::prelude::DebugName
+pub mod debug_name {
+    use bevy::utils::prelude::DebugName;
+    use serde::{Deserialize, Serialize};
+
+    /// Serializes a [`DebugName`] into a [`String`].
+    pub fn serialize<S>(name: &DebugName, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        name.to_string().serialize(serializer)
+    }
+
+    /// Deserializes a [`String`] into a [`DebugName`].
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<DebugName, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let name = String::deserialize(deserializer)?;
+        Ok(DebugName::from(name))
+    }
+}
+
+/// Serde helper module to serialize [`StorageType`] as a string.
+///
+/// ## Usage
+///
+/// Add `#[serde(with = "crate::serde_conversions::storage_type")]`
+/// to the struct's [`StorageType`] field.
+///
+/// [`StorageType`]: bevy::ecs::component::StorageType
+pub mod storage_type {
+    use bevy::ecs::component::StorageType;
+    use serde::{Deserialize, Serialize};
+
+    /// Serializes a [`StorageType`] into a [`String`].
+    pub fn serialize<S>(storage_type: &StorageType, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        format!("{storage_type:?}").serialize(serializer)
+    }
+
+    /// Deserializes a [`String`] into a [`StorageType`].
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<StorageType, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "Table" => Ok(StorageType::Table),
+            "SparseSet" => Ok(StorageType::SparseSet),
+            other => Err(serde::de::Error::unknown_variant(
+                other,
+                &["Table", "SparseSet"],
+            )),
+        }
+    }
+}
+
+/// Serde helper module to serialize a `HashMap<ComponentId, ComponentTypeMetadata>`
+/// where keys are serialized as integer indexes.
+///
+/// ## Usage
+///
+/// Add `#[serde(with = "crate::serde_conversions::hash_map_component_id_component_type_metadata")]`
+/// to the struct's `HashMap<ComponentId, ComponentTypeMetadata>` field.
+pub mod hash_map_component_id_component_type_metadata {
+    use crate::component_inspection::ComponentTypeMetadata;
+    use bevy::ecs::component::ComponentId;
+    use bevy::platform::collections::HashMap;
+    use serde::ser::SerializeMap;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    /// Serializes a `HashMap<ComponentId, ComponentTypeMetadata>` using `usize` as keys.
+    pub fn serialize<S>(
+        map: &HashMap<ComponentId, ComponentTypeMetadata>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_map(Some(map.len()))?;
+        for (key, value) in map {
+            seq.serialize_entry(&key.index(), value)?;
+        }
+        seq.end()
+    }
+
+    /// Deserializes a map of indexes into `HashMap<ComponentId, ComponentTypeMetadata>`.
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<HashMap<ComponentId, ComponentTypeMetadata>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let index_to_metadata: HashMap<usize, ComponentTypeMetadata> =
+            HashMap::deserialize(deserializer)?;
+        let component_id_to_metadata = index_to_metadata
+            .into_iter()
+            .map(|(key, value)| (ComponentId::new(key), value))
+            .collect();
+        Ok(component_id_to_metadata)
+    }
+}
+
+pub mod option_vec_debug_name {
+    use bevy::utils::prelude::DebugName;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(value: &Option<Vec<DebugName>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(debug_names) => {
+                let strings: Vec<String> = debug_names
+                    .iter()
+                    .map(|debug_name| debug_name.to_string())
+                    .collect();
+                serializer.serialize_some(&strings)
+            }
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<DebugName>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let opt_strings: Option<Vec<String>> = Option::deserialize(deserializer)?;
+        Ok(opt_strings.map(|strings| strings.into_iter().map(DebugName::from).collect()))
+    }
+}
+
+/// Serializes [`SpawnDetails`].
+pub fn serialize_spawn_details<S>(
+    spawn_details: &SpawnDetails,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    format!("{spawn_details:?}").serialize(serializer)
+}
+
+/// Serializes [`EntityDoesNotExistError`].
+pub fn serialize_entity_does_not_exist_error<S>(
+    error: &EntityDoesNotExistError,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    format!("{error:?}").serialize(serializer)
+}
+
+/// Serializes [`QueryEntityError`].
+pub fn serialize_query_entity_error<S>(
+    error: &QueryEntityError,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    format!("{error:?}").serialize(serializer)
+}

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -8,7 +8,8 @@ use bevy::{
 };
 
 /// Settings for [`WorldSummary`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SummarySettings {
     /// Whether to use component names
     /// for formatting archetype signatures.
@@ -32,16 +33,29 @@ impl Default for SummarySettings {
 
 /// Per-archetype data in an inspection summary.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ArchetypeSummary {
     /// The id of this archetype.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_conversions::archetype_id")
+    )]
     pub archetype_id: ArchetypeId,
     /// How many entities are in this archetype.
     pub entity_count: usize,
     /// What components define this archetype.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_conversions::slice_component_id")
+    )]
     pub component_ids: Vec<ComponentId>,
     /// The names of the components defining this archetype.
     ///
     /// Optional value determined by [`SummarySettings::include_component_names`].
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_conversions::option_vec_debug_name")
+    )]
     pub component_names: Option<Vec<DebugName>>,
 }
 
@@ -76,6 +90,7 @@ impl std::fmt::Display for ArchetypeSummary {
 
 /// [`World`] data summary result.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WorldSummary {
     /// The number of entities.
     pub total_entities: u32,


### PR DESCRIPTION
Adds a basic BRP infrastructure with functional handler for `World` extension methods, `ComponentMetadataMap::generate`, and fuzzy name mapping.

The pre-existing codebase remains mostly untouched, apart from the `serde` integration.

## Cargo features

This PR also adds two new Cargo features:

- `serde`: Intended to be enabled by users that want to serialize/deserialize library items.
- `remote`: Intended to be enabled by users that want to attach a BRP client to the app. It automatically enables `serde` and `bevy_remote` features under the hood, other than adding the optional `serde_json` dependency (for receiving and sending JSON-RPC `Value`s).

The `ureq` crate is added as a dev-dependency for the `brp_client` example, choice inspired by Bevy's `client` example.

The new module `brp`, which defines and adds the custom BRP methods to `RemotePlugin` is gated behind the `remote` feature.

## Examples

To demonstrate BRP usage, two examples have been added: `brp_server` and `brp_client`.

## Notes

- I edited the `cargo test` CI job to include `--all-features`, since omitting that now causes CI failures for examples.
- I skipped serialization for some fields in some structs since it is very impractical or even impossible (e.g. non-`Default` Bevy structs with private fields and no public constructors, like `SpawnDetails` and some error types).
- I intentionally left out usage of opaque internal Bevy items (like `ComponentId`) as parameters in exchange for more stable identifiers, like full component names.