### PR TITLE
cleanup some option calls

### DIFF
--- a/src/entity_grouping/hierarchy_grouping.rs
+++ b/src/entity_grouping/hierarchy_grouping.rs
@@ -52,8 +52,7 @@ fn collect_root_entities(world: &World, entities: &HashSet<Entity>) -> Vec<Entit
         .filter(|&entity| {
             let has_parent_in_set = world
                 .get::<ChildOf>(entity)
-                .map(|child_of| entities.contains(&child_of.parent()))
-                .unwrap_or(false);
+                .is_some_and(|child_of| entities.contains(&child_of.parent()));
             !has_parent_in_set
         })
         .collect()

--- a/src/entity_name_resolution/fuzzy_name_mapping.rs
+++ b/src/entity_name_resolution/fuzzy_name_mapping.rs
@@ -43,8 +43,7 @@ pub fn fuzzy_component_name_to_id(world: &World, fuzzy_name: &str) -> Option<Com
             return Some(id);
         }
         let similarity = normalized_levenshtein(&processed_fuzzy_name, &name);
-        if similarity >= THRESHOLD
-            && (best_match.is_none() || similarity > best_match.as_ref().unwrap().1)
+        if similarity >= THRESHOLD && best_match.is_none_or(|best_match| similarity > best_match.1)
         {
             best_match = Some((id, similarity));
         }
@@ -85,8 +84,7 @@ pub fn fuzzy_resource_name_to_id(world: &World, fuzzy_name: &str) -> Option<Comp
             return Some(id);
         }
         let similarity = normalized_levenshtein(&processed_fuzzy_name, &name);
-        if similarity >= THRESHOLD
-            && (best_match.is_none() || similarity > best_match.as_ref().unwrap().1)
+        if similarity >= THRESHOLD && best_match.is_none_or(|best_match| similarity > best_match.1)
         {
             best_match = Some((id, similarity));
         }

--- a/src/gui/panels/detail_panel.rs
+++ b/src/gui/panels/detail_panel.rs
@@ -546,11 +546,10 @@ fn spawn_components_tab_exclusive(
                 format!("Entity {:?}", entity).as_str(),
             ));
 
-            let component_count = inspection.components.as_ref().map(|c| c.len()).unwrap_or(0);
+            let component_count = inspection.components.as_ref().map_or(0, |c| c.len());
             let memory_display = inspection
                 .total_memory_size
-                .map(|m| m.to_string())
-                .unwrap_or_else(|| "?".to_string());
+                .map_or_else(|| "?".to_string(), |m| m.to_string());
 
             // Collect component IDs for reflection access
             let component_ids: Vec<_> = inspection
@@ -575,12 +574,8 @@ fn spawn_components_tab_exclusive(
             for comp_id in &component_ids {
                 // Get metadata for this component
                 let meta = metadata_map.map.get(comp_id);
-                let name = meta
-                    .map(|m| m.name.shortname().to_string())
-                    .unwrap_or_else(|| "?".to_string());
-                let size = meta
-                    .map(|m| m.memory_size.to_string())
-                    .unwrap_or_else(|| "?".to_string());
+                let name = meta.map_or_else(|| "?".to_string(), |m| m.name.shortname().to_string());
+                let size = meta.map_or_else(|| "?".to_string(), |m| m.memory_size.to_string());
                 let component_type_id = meta.and_then(|m| m.type_id);
 
                 // Try to get reflected component data
@@ -766,8 +761,7 @@ fn spawn_relationships_tab_exclusive(
     let parent_node_data = parent_entity.map(|e| {
         let name = world
             .get::<Name>(e)
-            .map(|n| n.as_str().to_string())
-            .unwrap_or_else(|| format!("Entity {:?}", e));
+            .map_or_else(|| format!("Entity {:?}", e), |n| n.as_str().to_string());
         let component_count = world
             .inspect(e, EntityInspectionSettings::default())
             .ok()
@@ -781,8 +775,8 @@ fn spawn_relationships_tab_exclusive(
         .map(|&e| {
             let name = world
                 .get::<Name>(e)
-                .map(|n| n.as_str().to_string())
-                .unwrap_or_else(|| format!("Entity {:?}", e));
+                .map_or_else(|| format!("Entity {:?}", e), |n| n.as_str().to_string());
+
             let component_count = world
                 .inspect(e, EntityInspectionSettings::default())
                 .ok()

--- a/src/gui/widgets/drag_value.rs
+++ b/src/gui/widgets/drag_value.rs
@@ -147,10 +147,9 @@ fn drag_value_on_click(
         let now = Instant::now();
 
         // Check for double-click
-        let is_double_click = drag_state
-            .last_click_time
-            .map(|last| now.duration_since(last) < Duration::from_millis(DOUBLE_CLICK_THRESHOLD_MS))
-            .unwrap_or(false);
+        let is_double_click = drag_state.last_click_time.is_some_and(|last| {
+            now.duration_since(last) < Duration::from_millis(DOUBLE_CLICK_THRESHOLD_MS)
+        });
 
         if is_double_click && !drag_state.editing {
             // Enter edit mode

--- a/src/inspection/entity_inspection.rs
+++ b/src/inspection/entity_inspection.rs
@@ -292,8 +292,7 @@ fn does_entity_match_inspection_filter(
     if let Some(name_filter) = &settings.name_filter {
         let name_matches = world
             .get::<Name>(entity)
-            .map(|name| name_filter.matches(name.as_str()))
-            .unwrap_or(false);
+            .is_some_and(|name| name_filter.matches(name.as_str()));
         if !name_matches {
             return false;
         }


### PR DESCRIPTION
# Objective 

Some small style changes I personally like when dealing with Options that I found while trying to get myself familiar with the code.

I was just grepping for `unwarp_or` so I hope I didn't miss any.