### PR TITLE
Make inspector window a child of `PrimaryWindow`

### DIFF
--- a/src/gui/plugin.rs
+++ b/src/gui/plugin.rs
@@ -11,7 +11,7 @@ use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
 use bevy::picking::hover::HoverMap;
 use bevy::prelude::*;
 use bevy::ui::Val::*;
-use bevy::window::{WindowRef, WindowResolution};
+use bevy::window::{PrimaryWindow, WindowRef, WindowResolution};
 
 use crate::gui::panels::{
     RefreshObjectList, on_object_row_click, refresh_object_list_periodically,
@@ -106,7 +106,11 @@ impl Plugin for InspectorWindowPlugin {
 }
 
 /// Spawns the inspector window on startup.
-fn setup_inspector_window(mut commands: Commands, mut window_state: ResMut<InspectorWindowState>) {
+fn setup_inspector_window(
+    primary_window: Query<Entity, With<PrimaryWindow>>,
+    mut commands: Commands,
+    mut window_state: ResMut<InspectorWindowState>,
+) {
     let window_entity = commands
         .spawn((
             Window {
@@ -120,6 +124,15 @@ fn setup_inspector_window(mut commands: Commands, mut window_state: ResMut<Inspe
             ViewVisibility::default(),
         ))
         .id();
+
+    // Inserting the inspector window as a child of the primary window
+    // allows the app to close when closing the primary window.
+    // Otherwise, you would need to close both windows.
+    if let Ok(primary_window_entity) = primary_window.single() {
+        commands
+            .entity(window_entity)
+            .insert(ChildOf(primary_window_entity));
+    }
 
     window_state.window_entity = Some(window_entity);
     window_state.is_open = true;


### PR DESCRIPTION
Currently, (at least on my system), if there is at least one window open, the app won't quit. This is a bit cumbersome and suboptimal from a UX perspective.

This PR makes the inspector window a child of the `PrimaryWindow`, if that's present. So, if the primary window gets closed, the inspector window won't hang around, and gets closed immediately. If only the inspector window gets closed, the parent `PrimaryWindow` will stay open, and the app won't quit.

I'm not a windowing expert, but hopefully creating window hierarchies doesn't have side effects.