### PR TITLE
Add implementable widgets to inspection panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "objc2 0.5.2",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -63,8 +63,8 @@ dependencies = [
  "accesskit_consumer",
  "hashbrown 0.16.1",
  "static_assertions",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -116,9 +116,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alsa"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
 dependencies = [
  "alsa-sys",
  "bitflags 2.11.0",
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "alsa-sys"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
 dependencies = [
  "libc",
  "pkg-config",
@@ -150,9 +150,9 @@ dependencies = [
  "jni-sys",
  "libc",
  "log",
- "ndk 0.9.0",
+ "ndk",
  "ndk-context",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "thiserror 1.0.69",
 ]
@@ -352,7 +352,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 [[package]]
 name = "bevy"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_internal",
 ]
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -373,7 +373,7 @@ dependencies = [
 [[package]]
 name = "bevy_android"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "android-activity",
 ]
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_animation_macros",
  "bevy_app",
@@ -413,7 +413,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation_macros"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -423,7 +423,7 @@ dependencies = [
 [[package]]
 name = "bevy_anti_alias"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -434,7 +434,6 @@ dependencies = [
  "bevy_ecs",
  "bevy_image",
  "bevy_math",
- "bevy_post_process",
  "bevy_reflect",
  "bevy_render",
  "bevy_shader",
@@ -445,7 +444,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -467,7 +466,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -509,7 +508,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -520,7 +519,7 @@ dependencies = [
 [[package]]
 name = "bevy_audio"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -528,8 +527,6 @@ dependencies = [
  "bevy_math",
  "bevy_reflect",
  "bevy_transform",
- "coreaudio-sys",
- "cpal",
  "rodio",
  "tracing",
 ]
@@ -537,7 +534,7 @@ dependencies = [
 [[package]]
 name = "bevy_camera"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -562,7 +559,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -577,7 +574,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -605,7 +602,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -615,7 +612,7 @@ dependencies = [
 [[package]]
 name = "bevy_dev_tools"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -646,7 +643,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "atomic-waker",
  "bevy_app",
@@ -663,7 +660,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -676,6 +673,7 @@ dependencies = [
  "bumpalo",
  "concurrent-queue",
  "derive_more",
+ "downcast-rs 2.0.2",
  "fixedbitset",
  "indexmap",
  "log",
@@ -690,7 +688,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -701,7 +699,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
@@ -710,7 +708,7 @@ dependencies = [
 [[package]]
 name = "bevy_feathers"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -739,7 +737,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -754,7 +752,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -773,7 +771,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -783,7 +781,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_render"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -808,7 +806,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "async-lock",
  "base64",
@@ -825,13 +823,12 @@ dependencies = [
  "bevy_mesh",
  "bevy_platform",
  "bevy_reflect",
- "bevy_render",
  "bevy_scene",
  "bevy_tasks",
  "bevy_transform",
  "fixedbitset",
  "gltf",
- "itertools 0.14.0",
+ "itertools",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -844,7 +841,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -872,7 +869,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -889,7 +886,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -905,7 +902,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_a11y",
  "bevy_android",
@@ -943,6 +940,7 @@ dependencies = [
  "bevy_remote",
  "bevy_render",
  "bevy_scene",
+ "bevy_scene2",
  "bevy_shader",
  "bevy_sprite",
  "bevy_sprite_render",
@@ -962,7 +960,7 @@ dependencies = [
 [[package]]
 name = "bevy_light"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -986,7 +984,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1003,18 +1001,18 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "toml_edit 0.24.1+spec-1.1.0",
+ "toml_edit 0.25.4+spec-1.1.0",
 ]
 
 [[package]]
 name = "bevy_material"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1036,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "bevy_material_macros"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -1046,14 +1044,14 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "approx",
  "arrayvec",
  "bevy_reflect",
  "derive_more",
  "glam",
- "itertools 0.14.0",
+ "itertools",
  "libm",
  "rand",
  "rand_distr",
@@ -1065,13 +1063,13 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_derive",
  "bevy_ecs",
- "bevy_image",
+ "bevy_encase_derive",
  "bevy_math",
  "bevy_mikktspace",
  "bevy_platform",
@@ -1080,6 +1078,9 @@ dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "derive_more",
+ "encase",
+ "glam",
+ "half",
  "hexasphere",
  "serde",
  "thiserror 2.0.18",
@@ -1096,8 +1097,9 @@ checksum = "bff34eb29ff4b8a8688bc7299f14fb6b597461ca80fec03ed7d22939ab33e48f"
 [[package]]
 name = "bevy_pbr"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
+ "arrayvec",
  "bevy_app",
  "bevy_asset",
  "bevy_camera",
@@ -1131,12 +1133,13 @@ dependencies = [
  "static_assertions",
  "thiserror 2.0.18",
  "tracing",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_picking"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1159,7 +1162,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "async-io",
  "critical-section",
@@ -1175,13 +1178,13 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "bevy_post_process"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1205,12 +1208,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1238,7 +1241,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_macro_utils",
  "indexmap",
@@ -1251,7 +1254,7 @@ dependencies = [
 [[package]]
 name = "bevy_remote"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1275,7 +1278,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "async-channel",
  "bevy_app",
@@ -1309,7 +1312,7 @@ dependencies = [
  "glam",
  "image",
  "indexmap",
- "itertools 0.14.0",
+ "itertools",
  "js-sys",
  "naga",
  "nonmax",
@@ -1319,6 +1322,7 @@ dependencies = [
  "thiserror 2.0.18",
  "variadics_please",
  "wasm-bindgen",
+ "weak-table",
  "web-sys",
  "wgpu",
  "wgpu-types",
@@ -1327,7 +1331,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1338,7 +1342,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1357,9 +1361,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_scene2"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_log",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_scene2_macros",
+ "bevy_utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "variadics_please",
+]
+
+[[package]]
+name = "bevy_scene2_macros"
+version = "0.19.0-dev"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
+dependencies = [
+ "bevy_macro_utils",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bevy_shader"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_asset",
  "bevy_platform",
@@ -1370,13 +1404,14 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tracing",
+ "wgpu-naga-bridge",
  "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_sprite"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1401,7 +1436,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite_render"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1433,7 +1468,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1448,7 +1483,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -1458,7 +1493,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -1476,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1503,7 +1538,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1517,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1534,7 +1569,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1554,10 +1589,12 @@ dependencies = [
  "bevy_reflect",
  "bevy_sprite",
  "bevy_text",
+ "bevy_time",
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
  "derive_more",
+ "parley",
  "serde",
  "smallvec",
  "taffy",
@@ -1569,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui_render"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1600,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui_widgets"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1613,13 +1650,16 @@ dependencies = [
  "bevy_math",
  "bevy_picking",
  "bevy_reflect",
+ "bevy_text",
  "bevy_ui",
+ "parley",
+ "smol_str",
 ]
 
 [[package]]
 name = "bevy_utils"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "async-channel",
  "bevy_platform",
@@ -1630,7 +1670,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1648,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.19.0-dev"
-source = "git+https://github.com/bevyengine/bevy.git?rev=586f2617200e9b241b42b7835a1c2f2e4faceb50#586f2617200e9b241b42b7835a1c2f2e4faceb50"
+source = "git+https://github.com/bevyengine/bevy.git?rev=f4d17d9eb2ab038deb3e8dd462351cd43fb32390#f4d17d9eb2ab038deb3e8dd462351cd43fb32390"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -1679,37 +1719,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.1",
- "shlex",
- "syn",
-]
-
-[[package]]
 name = "bit-set"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
@@ -1740,12 +1762,6 @@ dependencies = [
  "constant_time_eq",
  "cpufeatures",
 ]
-
-[[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block2"
@@ -1867,15 +1883,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,21 +1895,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "codespan-reporting"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
@@ -2024,16 +2031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2046,8 +2043,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
+ "core-foundation",
+ "core-graphics-types",
  "foreign-types",
  "libc",
 ]
@@ -2059,18 +2056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "libc",
 ]
 
@@ -2085,45 +2071,46 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.11.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+checksum = "d15c3c3cee7c087938f7ad1c3098840b3ef1f1bdc7f6e496336c3b1e7a6f3914"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation-sys",
- "coreaudio-sys",
-]
-
-[[package]]
-name = "coreaudio-sys"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
-dependencies = [
- "bindgen",
+ "bitflags 2.11.0",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
 ]
 
 [[package]]
 name = "cpal"
-version = "0.15.3"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
 dependencies = [
  "alsa",
- "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
  "jni",
  "js-sys",
  "libc",
  "mach2",
- "ndk 0.8.0",
+ "ndk",
  "ndk-context",
- "oboe",
+ "num-derive",
+ "num-traits",
+ "objc2 0.6.3",
+ "objc2-audio-toolbox",
+ "objc2-avf-audio",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows 0.54.0",
+ "windows",
 ]
 
 [[package]]
@@ -2685,7 +2672,7 @@ dependencies = [
  "vec_map",
  "wasm-bindgen",
  "web-sys",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -2713,16 +2700,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "glow"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -2786,7 +2767,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -2831,9 +2812,11 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
+ "serde",
  "zerocopy",
 ]
 
@@ -3158,15 +3141,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -3361,18 +3335,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -3402,27 +3367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metal"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7047791b5bc903b8cd963014b355f71dc9864a9a0b727057676c1dcae5cbc15"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "core-graphics-types 0.2.0",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3444,16 +3388,16 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "28.0.0"
+version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618f667225063219ddfc61251087db8a9aec3c3f0950c916b614e403486f1135"
+checksum = "aa2630921705b9b01dcdd0b6864b9562ca3c1951eecd0f0c4f5f04f61e412647"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
- "codespan-reporting",
+ "codespan-reporting 0.13.1",
  "half",
  "hashbrown 0.16.1",
  "hexf-parse",
@@ -3463,7 +3407,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pp-rs",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "spirv",
  "thiserror 2.0.18",
  "unicode-ident",
@@ -3471,33 +3415,19 @@ dependencies = [
 
 [[package]]
 name = "naga_oil"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f13ea787c55e7b2d1ab69b57847a8bfb19278da89dc5cd72701dced496314b"
+checksum = "319f03062940ed85c03da020042618356bb8ca5263020322930883b05e30208e"
 dependencies = [
- "codespan-reporting",
+ "codespan-reporting 0.12.0",
  "data-encoding",
  "indexmap",
  "naga",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "thiserror 2.0.18",
  "tracing",
  "unicode-ident",
-]
-
-[[package]]
-name = "ndk"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
-dependencies = [
- "bitflags 2.11.0",
- "jni-sys",
- "log",
- "ndk-sys 0.5.0+25.2.9519653",
- "num_enum",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3509,7 +3439,7 @@ dependencies = [
  "bitflags 2.11.0",
  "jni-sys",
  "log",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -3520,15 +3450,6 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
-dependencies = [
- "jni-sys",
-]
 
 [[package]]
 name = "ndk-sys"
@@ -3549,16 +3470,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -3586,6 +3497,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3600,6 +3521,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3632,15 +3573,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
 ]
 
 [[package]]
@@ -3680,8 +3612,33 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-core-data",
  "objc2-core-image",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "objc2 0.6.3",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3694,7 +3651,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3705,7 +3662,30 @@ checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2 0.6.3",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -3717,7 +3697,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3727,6 +3707,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
+ "dispatch2",
+ "libc",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -3737,8 +3721,8 @@ checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-foundation",
- "objc2-metal",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -3750,7 +3734,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-contacts",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3773,6 +3757,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,7 +3789,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3804,7 +3801,19 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3816,8 +3825,21 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-foundation",
- "objc2-metal",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -3827,7 +3849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
  "objc2 0.5.2",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3843,9 +3865,9 @@ dependencies = [
  "objc2-core-data",
  "objc2-core-image",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
@@ -3859,7 +3881,7 @@ checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3872,30 +3894,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
-]
-
-[[package]]
-name = "oboe"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
-dependencies = [
- "jni",
- "ndk 0.8.0",
- "ndk-context",
- "num-derive",
- "num-traits",
- "oboe-sys",
-]
-
-[[package]]
-name = "oboe-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
-dependencies = [
- "cc",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3993,12 +3992,6 @@ dependencies = [
  "skrifa",
  "swash",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -4252,6 +4245,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
 name = "read-fonts"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4346,12 +4351,15 @@ dependencies = [
 
 [[package]]
 name = "rodio"
-version = "0.20.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ceb6607dd738c99bc8cb28eff249b7cd5c8ec88b9db96c0608c1480d140fb1"
+checksum = "d0a536bb79db59098ef71a4dd4246c02eb87b316deceb1b68e0cde7167ec01eb"
 dependencies = [
  "cpal",
+ "dasp_sample",
  "lewton",
+ "num-rational",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4373,12 +4381,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -4667,9 +4669,9 @@ dependencies = [
 
 [[package]]
 name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
+version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -4763,16 +4765,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.0"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe840c5b1afe259a5657392a4dbb74473a14c8db999c3ec2f4ae812e028a94da"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -4946,25 +4948,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.24.1+spec-1.1.0"
+version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -5445,8 +5456,15 @@ checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
 dependencies = [
  "dlib",
  "log",
+ "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "weak-table"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
@@ -5479,9 +5497,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "28.0.0"
+version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cb534d5ffd109c7d1135f34cdae29e60eab94855a625dcfe1705f8bc7ad79f"
+checksum = "72c239a9a747bbd379590985bac952c2e53cb19873f7072b3370c6a6a8e06837"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.0",
@@ -5507,9 +5525,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "28.0.0"
+version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb4c8b5db5f00e56f1f08869d870a0dff7c8bc7ebc01091fec140b0cf0211a9"
+checksum = "1e80ac6cf1895df6342f87d975162108f9d98772a0d74bc404ab7304ac29469e"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -5527,59 +5545,59 @@ dependencies = [
  "portable-atomic",
  "profiling",
  "raw-window-handle",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "smallvec",
  "thiserror 2.0.18",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-wasm",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
+ "wgpu-naga-bridge",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b7b696b918f337c486bf93142454080a32a37832ba8a31e4f48221890047da"
+checksum = "43acd053312501689cd92a01a9638d37f3e41a5fd9534875efa8917ee2d11ac0"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-wasm"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a2cf578ce8d7d50d0e63ddc2345c7dcb599f6eb90b888813406ea78b9b7010"
+checksum = "2f7b75e72f49035f000dd5262e4126242e92a090a4fd75931ecfe7e60784e6fa"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ca976e72b2c9964eb243e281f6ce7f14a514e409920920dcda12ae40febaae"
+checksum = "725d5c006a8c02967b6d93ef04f6537ec4593313e330cfe86d9d3f946eb90f28"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "28.0.0"
+version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293080d77fdd14d6b08a67c5487dfddbf874534bb7921526db56a7b75d7e3bef"
+checksum = "89a47aef47636562f3937285af4c44b4b5b404b46577471411cc5313a921da7e"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
  "bitflags 2.11.0",
- "block",
+ "block2 0.6.2",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
  "gpu-allocator",
@@ -5590,10 +5608,13 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "metal",
  "naga",
- "ndk-sys 0.6.0+11769913",
- "objc",
+ "ndk-sys",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "once_cell",
  "ordered-float",
  "parking_lot",
@@ -5602,26 +5623,40 @@ dependencies = [
  "profiling",
  "range-alloc",
  "raw-window-handle",
+ "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
  "thiserror 2.0.18",
  "wasm-bindgen",
+ "wayland-sys",
  "web-sys",
+ "wgpu-naga-bridge",
  "wgpu-types",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows",
+ "windows-core",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4684f4410da0cf95a4cb63bb5edaac022461dedb6adf0b64d0d9b5f6890d51"
+dependencies = [
+ "naga",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "28.0.0"
+version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18308757e594ed2cd27dddbb16a139c42a683819d32a2e0b1b0167552f5840c"
+checksum = "ec2675540fb1a5cfa5ef122d3d5f390e2c75711a0b946410f2d6ac3a0f77d1f6"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "js-sys",
  "log",
+ "raw-window-handle",
  "serde",
  "web-sys",
 ]
@@ -5659,22 +5694,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
-dependencies = [
- "windows-core 0.54.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -5685,17 +5710,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
-dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -5707,7 +5722,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
 ]
 
@@ -5717,7 +5732,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
 ]
@@ -5756,17 +5771,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5968,17 +5974,17 @@ dependencies = [
  "calloop",
  "cfg_aliases",
  "concurrent-queue",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics",
  "cursor-icon",
  "dpi",
  "js-sys",
  "libc",
  "memmap2",
- "ndk 0.9.0",
+ "ndk",
  "objc2 0.5.2",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-ui-kit",
  "orbclient",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ opt-level = 1
 opt-level = 3
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "586f2617200e9b241b42b7835a1c2f2e4faceb50", features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "f4d17d9eb2ab038deb3e8dd462351cd43fb32390", features = [
 	"track_location",
 	"experimental_bevy_feathers",
 	"debug",

--- a/src/gui/cache/systems.rs
+++ b/src/gui/cache/systems.rs
@@ -174,10 +174,9 @@ fn update_cache_paused(
     state: &mut SystemState<MessageReader<RefreshCache>>,
     filter: &ObjectListFilter,
 ) {
-    let force = state
-        .get_mut(world)
-        .read()
-        .any(|refresh_cache| refresh_cache.force);
+    let force = state.get_mut(world).map_or(false, |mut state| {
+        state.read().any(|refresh_cache| refresh_cache.force)
+    });
     let has_full_snapshot = {
         let cache = world.resource::<InspectorCache>();
         cache.snapshot.is_full()

--- a/src/gui/panels/detail_panel.rs
+++ b/src/gui/panels/detail_panel.rs
@@ -14,8 +14,6 @@ use bevy::reflect::{ReflectRef, enums::VariantType};
 use bevy::ui::Val::*;
 use bevy::ui_widgets::{Activate, ControlOrientation, CoreScrollbarThumb, Scrollbar, observe};
 
-use core::any::TypeId;
-
 use crate::entity_name_resolution::EntityName;
 use crate::extension_methods::WorldInspectionExtensionTrait;
 use crate::gui::cache::InspectorCache;
@@ -23,7 +21,9 @@ use crate::gui::config::InspectorConfig;
 use crate::gui::plugin::RefreshCache;
 use crate::gui::semantic_names::SemanticFieldNames;
 use crate::gui::state::{DetailTab, InspectorState};
-use crate::gui::widgets::drag_value::{DragValue, DragValueDragState, FieldPath, FieldPathSegment};
+use crate::gui::widgets::drag_value::DragValueDragState;
+use crate::gui::widgets::registry::{WidgetBuilder, WidgetRegistry};
+use crate::gui::widgets::{FieldPath, FieldPathSegment};
 use crate::inspection::component_inspection::ComponentMetadataMap;
 use crate::inspection::entity_inspection::{EntityInspection, EntityInspectionSettings};
 
@@ -238,18 +238,8 @@ fn render_active_tab(
 /// Represents a field extracted from a reflected component
 struct ReflectedField {
     name: String,
-    value: String,
     indent: u8,
-    /// If this is an editable numeric field, contains the numeric value and path segments
-    editable: Option<EditableFieldInfo>,
-}
-
-/// Information needed to make a field editable
-struct EditableFieldInfo {
-    /// The numeric value (as f64 for generality)
-    numeric_value: f64,
-    /// Path segments to reach this field from the component root
-    path: Vec<FieldPathSegment>,
+    widget: WidgetBuilder,
 }
 
 /// Extracts fields from a reflected value into a flat list of label/value pairs.
@@ -259,205 +249,152 @@ fn extract_fields_from_reflect(
     reflected: &dyn PartialReflect,
     fields: &mut Vec<ReflectedField>,
     indent: u8,
+    widget_registry: &WidgetRegistry,
+    config: &InspectorConfig,
     semantic_names: &SemanticFieldNames,
-    current_path: &[FieldPathSegment],
+    path: Option<FieldPath>,
+    name: Option<&str>,
 ) {
-    // Get the TypeId of this reflected value for semantic name lookup
-    let type_id = reflected
-        .get_represented_type_info()
-        .map(|info| info.type_id());
+    let (type_name, type_id) = reflected.get_represented_type_info().map_or_else(
+        || ("?".to_owned(), None),
+        |info| {
+            (
+                ShortName::from(info.type_path()).to_string(),
+                Some(info.type_id()),
+            )
+        },
+    );
 
-    match reflected.reflect_ref() {
-        ReflectRef::Struct(s) => {
-            for i in 0..s.field_len() {
-                let field_name = s.name_at(i).unwrap_or("?");
-                let field_value = s.field_at(i).unwrap();
-
-                // Build path to this field
-                let mut field_path = current_path.to_vec();
-                field_path.push(FieldPathSegment::Named(field_name.to_string()));
-
-                // Check if this is an editable numeric field
-                let editable = try_extract_numeric(field_value).map(|num| EditableFieldInfo {
-                    numeric_value: num,
-                    path: field_path.clone(),
-                });
-
-                let value_str = format_simple_value(field_value);
-                if let Some(val) = value_str {
+    if let Some(path) = &path
+        && let Some(widget) = widget_registry.get_widget(reflected, path, config)
+    {
+        fields.push(ReflectedField {
+            name: name.unwrap_or("?").to_owned(),
+            indent,
+            widget,
+        });
+    } else {
+        match reflected.reflect_ref() {
+            ReflectRef::Struct(s) => {
+                // Complex nested type - add header and recurse
+                if let Some(name) = name {
                     fields.push(ReflectedField {
-                        name: field_name.to_string(),
-                        value: val,
+                        name: name.to_owned(),
                         indent,
-                        editable,
+                        widget: widget_registry.label_widget(type_name, config),
                     });
-                } else {
-                    // Complex nested type - add header and recurse
-                    let type_name = field_value
-                        .get_represented_type_info()
-                        .map(|t| ShortName::from(t.type_path()).to_string())
-                        .unwrap_or_else(|| "?".to_string());
-                    fields.push(ReflectedField {
-                        name: field_name.to_string(),
-                        value: format!("[{}]", type_name),
-                        indent,
-                        editable: None,
+                }
+                for i in 0..s.field_len() {
+                    let field_name = s.name_at(i).unwrap_or("?");
+                    // Build path to this field
+                    let path = path.clone().map(|mut path| {
+                        path.path
+                            .push(FieldPathSegment::Named(field_name.to_string()));
+                        path
                     });
+                    let field_value = s.field_at(i).unwrap();
+
                     extract_fields_from_reflect(
                         field_value,
                         fields,
-                        indent + 1,
+                        indent.saturating_add(1),
+                        widget_registry,
+                        config,
                         semantic_names,
-                        &field_path,
+                        path,
+                        Some(field_name),
                     );
                 }
             }
-        }
-        ReflectRef::TupleStruct(ts) => {
-            for i in 0..ts.field_len() {
-                let field_value = ts.field(i).unwrap();
-
-                // Build path to this field (use Index for tuple structs)
-                let mut field_path = current_path.to_vec();
-                field_path.push(FieldPathSegment::Index(i));
-
-                // Check if this is an editable numeric field
-                let editable = try_extract_numeric(field_value).map(|num| EditableFieldInfo {
-                    numeric_value: num,
-                    path: field_path.clone(),
-                });
-
-                // Try to get semantic name (e.g., "x", "y", "z") for this field index
-                let field_name = type_id
-                    .and_then(|tid| semantic_names.get_field_name(tid, i))
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| format!(".{}", i));
-
-                let value_str = format_simple_value(field_value);
-                if let Some(val) = value_str {
+            ReflectRef::TupleStruct(ts) => {
+                if let Some(name) = name {
                     fields.push(ReflectedField {
-                        name: field_name,
-                        value: val,
+                        name: name.to_owned(),
                         indent,
-                        editable,
+                        widget: widget_registry.label_widget(type_name, config),
                     });
-                } else {
-                    let type_name = field_value
-                        .get_represented_type_info()
-                        .map(|t| ShortName::from(t.type_path()).to_string())
-                        .unwrap_or_else(|| "?".to_string());
-                    fields.push(ReflectedField {
-                        name: field_name,
-                        value: format!("[{}]", type_name),
-                        indent,
-                        editable: None,
+                }
+                for i in 0..ts.field_len() {
+                    // Build path to this field (use Index for tuple structs)
+                    let path = path.clone().map(|mut path| {
+                        path.path.push(FieldPathSegment::Index(i));
+                        path
                     });
+                    let field_value = ts.field(i).unwrap();
+
+                    // Try to get semantic name (e.g., "x", "y", "z") for this field index
+                    let field_name = type_id
+                        .and_then(|tid| semantic_names.get_field_name(tid, i))
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| format!(".{}", i));
+
                     extract_fields_from_reflect(
                         field_value,
                         fields,
-                        indent + 1,
+                        indent.saturating_add(1),
+                        widget_registry,
+                        config,
                         semantic_names,
-                        &field_path,
+                        path,
+                        Some(&field_name),
                     );
                 }
             }
-        }
-        ReflectRef::Enum(e) => {
-            let variant_name = e.variant_name();
-            match e.variant_type() {
-                VariantType::Unit => {
-                    fields.push(ReflectedField {
-                        name: "variant".to_string(),
-                        value: variant_name.to_string(),
-                        indent,
-                        editable: None,
-                    });
-                }
-                VariantType::Tuple => {
-                    fields.push(ReflectedField {
-                        name: "variant".to_string(),
-                        value: variant_name.to_string(),
-                        indent,
-                        editable: None,
-                    });
-                    for i in 0..e.field_len() {
-                        let field_value = e.field_at(i).unwrap();
-                        let value_str = format_simple_value(field_value);
-                        if let Some(val) = value_str {
-                            fields.push(ReflectedField {
-                                name: format!(".{}", i),
-                                value: val,
-                                indent: indent + 1,
-                                editable: None, // TODO: enum field editing
-                            });
-                        }
-                    }
-                }
-                VariantType::Struct => {
-                    fields.push(ReflectedField {
-                        name: "variant".to_string(),
-                        value: variant_name.to_string(),
-                        indent,
-                        editable: None,
-                    });
-                    for i in 0..e.field_len() {
-                        let field_name = e.name_at(i).unwrap_or("?");
-                        let field_value = e.field_at(i).unwrap();
-                        let value_str = format_simple_value(field_value);
-                        if let Some(val) = value_str {
-                            fields.push(ReflectedField {
-                                name: field_name.to_string(),
-                                value: val,
-                                indent: indent + 1,
-                                editable: None, // TODO: enum field editing
-                            });
-                        }
-                    }
-                }
-            }
-        }
-        _ => {
-            // For other types (List, Map, etc), just show a simple representation
-            if let Some(val) = format_simple_value(reflected) {
+            ReflectRef::Enum(e) => {
                 fields.push(ReflectedField {
-                    name: "value".to_string(),
-                    value: val,
+                    name: name.unwrap_or("variant").to_owned(),
                     indent,
-                    editable: None,
+                    widget: widget_registry.enum_widget(&type_name, e, config),
                 });
+
+                // Build path to this variant
+                let path = path.clone().map(|mut path| {
+                    path.path.push(FieldPathSegment::Index(e.variant_index()));
+                    path
+                });
+                for i in 0..e.field_len() {
+                    let field_name = e
+                        .name_at(i)
+                        .map(ToOwned::to_owned)
+                        .unwrap_or_else(|| format!(".{i}"));
+                    let field_value = e.field_at(i).unwrap();
+
+                    // Build path to this variant's field (use Index or Name)
+                    let path = path.clone().map(|mut path| {
+                        match e.variant_type() {
+                            VariantType::Unit => {}
+                            VariantType::Tuple => path.path.push(FieldPathSegment::Index(i)),
+                            VariantType::Struct => {
+                                path.path.push(FieldPathSegment::Named(field_name.clone()))
+                            }
+                        }
+                        path
+                    });
+
+                    extract_fields_from_reflect(
+                        field_value,
+                        fields,
+                        indent.saturating_add(1),
+                        widget_registry,
+                        config,
+                        semantic_names,
+                        path,
+                        Some(&field_name),
+                    );
+                }
+            }
+            _ => {
+                // For other types (List, Map, etc), just show a simple representation
+                if let Some(val) = format_simple_value(reflected) {
+                    fields.push(ReflectedField {
+                        name: name.unwrap_or("value").to_owned(),
+                        indent,
+                        widget: widget_registry.label_widget(val, config),
+                    });
+                }
             }
         }
     }
-}
-
-/// Tries to extract a numeric value from a reflected type.
-/// Returns the value as f64 if it's a supported numeric type.
-fn try_extract_numeric(reflected: &dyn PartialReflect) -> Option<f64> {
-    // Try f32
-    if let Some(val) = reflected.try_downcast_ref::<f32>() {
-        return Some(*val as f64);
-    }
-    // Try f64
-    if let Some(val) = reflected.try_downcast_ref::<f64>() {
-        return Some(*val);
-    }
-    // Try i32
-    if let Some(val) = reflected.try_downcast_ref::<i32>() {
-        return Some(*val as f64);
-    }
-    // Try i64
-    if let Some(val) = reflected.try_downcast_ref::<i64>() {
-        return Some(*val as f64);
-    }
-    // Try u32
-    if let Some(val) = reflected.try_downcast_ref::<u32>() {
-        return Some(*val as f64);
-    }
-    // Try u64
-    if let Some(val) = reflected.try_downcast_ref::<u64>() {
-        return Some(*val as f64);
-    }
-    None
 }
 
 /// Tries to format a value as a simple string, returns None if it's a complex type
@@ -489,10 +426,6 @@ struct ComponentCardData {
     name: String,
     size: String,
     fields: Vec<ReflectedField>,
-    /// The entity this component belongs to (for write-back)
-    entity: Entity,
-    /// The TypeId of this component (for write-back)
-    component_type_id: Option<TypeId>,
 }
 
 fn spawn_components_tab_exclusive(
@@ -503,6 +436,7 @@ fn spawn_components_tab_exclusive(
 ) {
     // Get semantic names resource for better tuple struct field names
     let semantic_names = world.resource::<SemanticFieldNames>();
+    let widget_registry = world.resource::<WidgetRegistry>();
 
     let resolved_name = inspection.name.clone().unwrap_or(EntityName::fallback(
         format!("Entity {:?}", inspection.entity).as_str(),
@@ -513,6 +447,7 @@ fn spawn_components_tab_exclusive(
         .total_memory_size
         .map_or_else(|| "?".to_string(), |m| m.to_string());
 
+    let inspector_config = world.resource::<InspectorConfig>();
     let &InspectorConfig {
         title_font_size,
         body_font_size,
@@ -522,7 +457,7 @@ fn spawn_components_tab_exclusive(
         border_color,
         muted_text_color,
         ..
-    } = world.resource::<InspectorConfig>();
+    } = inspector_config;
 
     let field_name_color = Color::srgba(0.6, 0.8, 1.0, 1.0); // Light blue for field names
 
@@ -542,31 +477,33 @@ fn spawn_components_tab_exclusive(
             // Try to get reflected component data from the inspection snapshot
             let mut fields = Vec::new();
 
+            let path = component_type_id.map(|component_type_id| FieldPath {
+                entity: inspection.entity,
+                component_type_id,
+                path: vec![],
+            });
+
             if let Some(reflected_box) = &component_inspection.reflected_value {
                 extract_fields_from_reflect(
                     reflected_box.as_ref(),
                     &mut fields,
                     0,
+                    &widget_registry,
+                    inspector_config,
                     semantic_names,
-                    &[],
+                    path,
+                    None,
                 );
             } else if let Some(value_str) = &component_inspection.value {
                 // Fallback to string value if reflected value not available
                 fields.push(ReflectedField {
                     name: "Value".to_string(),
-                    value: value_str.clone(),
                     indent: 0,
-                    editable: None,
+                    widget: widget_registry.label_widget(value_str.to_owned(), inspector_config),
                 });
             }
 
-            component_cards.push(ComponentCardData {
-                name,
-                size,
-                fields,
-                entity: inspection.entity,
-                component_type_id,
-            });
+            component_cards.push(ComponentCardData { name, size, fields });
         }
     }
 
@@ -619,8 +556,20 @@ fn spawn_components_tab_exclusive(
                     },
                 ));
 
+                // Show placeholder if no fields extracted
+                if card_data.fields.is_empty() {
+                    card.spawn((
+                        Text::new("<no reflected data>"),
+                        TextFont {
+                            font_size: FontSize::Px(small_font_size),
+                            ..default()
+                        },
+                        TextColor(muted_text_color),
+                    ));
+                }
+
                 // Field rows (dear imgui style)
-                for field in &card_data.fields {
+                for field in card_data.fields {
                     let indent_px = field.indent as f32 * 12.0;
 
                     // Row container for label: value
@@ -643,68 +592,8 @@ fn spawn_components_tab_exclusive(
                             TextColor(field_name_color),
                         ));
 
-                        // Check if this field is editable
-                        if let (Some(editable), Some(component_type_id)) =
-                            (&field.editable, card_data.component_type_id)
-                        {
-                            // Spawn DragValue widget for editable numeric fields
-                            let field_path = FieldPath {
-                                entity: card_data.entity,
-                                component_type_id,
-                                path: editable.path.clone(),
-                            };
-
-                            row.spawn((
-                                Node {
-                                    min_width: Px(60.0),
-                                    padding: UiRect::horizontal(Px(4.0)),
-                                    border: UiRect::all(Px(1.0)),
-                                    ..default()
-                                },
-                                BorderColor::all(Color::srgba(0.3, 0.3, 0.3, 1.0)),
-                                BackgroundColor(Color::srgba(0.15, 0.15, 0.15, 1.0)),
-                                DragValue {
-                                    field_path,
-                                    drag_speed: 0.1,
-                                    precision: 2,
-                                    min: None,
-                                    max: None,
-                                },
-                                DragValueDragState::default(),
-                                Interaction::default(),
-                            ))
-                            .with_child((
-                                Text::new(format!("{:.2}", editable.numeric_value)),
-                                TextFont {
-                                    font_size: FontSize::Px(small_font_size),
-                                    ..default()
-                                },
-                                TextColor(Color::srgba(0.9, 0.9, 0.6, 1.0)), // Yellow for editable
-                            ));
-                        } else {
-                            // Field value (muted) - non-editable
-                            row.spawn((
-                                Text::new(field.value.clone()),
-                                TextFont {
-                                    font_size: FontSize::Px(small_font_size),
-                                    ..default()
-                                },
-                                TextColor(muted_text_color),
-                            ));
-                        }
+                        field.widget.apply_widget(&mut row.spawn_empty());
                     });
-                }
-
-                // Show placeholder if no fields extracted
-                if card_data.fields.is_empty() {
-                    card.spawn((
-                        Text::new("<no reflected data>"),
-                        TextFont {
-                            font_size: FontSize::Px(small_font_size),
-                            ..default()
-                        },
-                        TextColor(muted_text_color),
-                    ));
                 }
             });
         }

--- a/src/gui/plugin.rs
+++ b/src/gui/plugin.rs
@@ -17,6 +17,7 @@ use bevy::window::{PrimaryWindow, WindowCloseRequested, WindowRef, WindowResolut
 
 use crate::gui::cache::{InspectorCache, periodically_refresh_cache, update_inspector_cache};
 use crate::gui::panels::{on_object_row_click, update_active_objects_tab_on_tab_activated};
+use crate::gui::widgets::registry::WidgetRegistry;
 
 use super::config::InspectorConfig;
 use super::panels::{
@@ -74,6 +75,7 @@ impl Plugin for InspectorWindowPlugin {
             .init_resource::<InspectorState>()
             .init_resource::<InspectorCache>()
             .init_resource::<SemanticFieldNames>()
+            .insert_resource(WidgetRegistry::default().with::<Vec3>().with::<f32>())
             // Messages
             .add_message::<SetInspectorWindow>()
             .add_message::<RefreshCache>()

--- a/src/gui/widgets/drag_value.rs
+++ b/src/gui/widgets/drag_value.rs
@@ -17,29 +17,10 @@ use core::any::TypeId;
 use std::time::{Duration, Instant};
 
 use crate::reflection_tools::get_component_reflect_mut;
+use super::{FieldPath, FieldPathSegment};
 
 /// Double-click detection threshold (in milliseconds)
 const DOUBLE_CLICK_THRESHOLD_MS: u64 = 300;
-
-/// Describes how to locate a field within a component for write-back.
-#[derive(Clone, Debug)]
-pub struct FieldPath {
-    /// The entity containing the component.
-    pub entity: Entity,
-    /// The TypeId of the component.
-    pub component_type_id: TypeId,
-    /// The path segments to navigate to the field.
-    pub path: Vec<FieldPathSegment>,
-}
-
-/// A segment in a field path.
-#[derive(Clone, Debug)]
-pub enum FieldPathSegment {
-    /// Named struct field: e.g., "translation"
-    Named(String),
-    /// Indexed tuple/array field: e.g., 0, 1, 2
-    Index(usize),
-}
 
 /// Props for spawning a DragValue widget.
 pub struct DragValueProps {
@@ -320,6 +301,18 @@ fn set_field_value_recursive(
                 && let Some(field) = t.field_mut(*idx)
             {
                 return set_field_value_recursive(field, remaining, new_value);
+            }
+        }
+        ReflectMut::Enum(e) => {
+            if let FieldPathSegment::Index(variant_idx) = segment
+                && variant_idx == &e.variant_index()
+                && let Some(field) = match remaining.first() {
+                    Some(FieldPathSegment::Index(idx)) => e.field_at_mut(*idx),
+                    Some(FieldPathSegment::Named(name)) => e.field_mut(name),
+                    None => None,
+                }
+            {
+                return set_field_value_recursive(field, &remaining[1..], new_value);
             }
         }
 

--- a/src/gui/widgets/mod.rs
+++ b/src/gui/widgets/mod.rs
@@ -6,4 +6,28 @@
 //!   - Double-click to enter text input mode
 
 pub mod drag_value;
+pub mod reflected;
+pub mod registry;
 pub mod tabs;
+
+use bevy::ecs::entity::Entity;
+use std::any::TypeId;
+/// Describes how to locate a field within a component for write-back.
+#[derive(Clone, Debug)]
+pub struct FieldPath {
+    /// The entity containing the component.
+    pub entity: Entity,
+    /// The TypeId of the component.
+    pub component_type_id: TypeId,
+    /// The path segments to navigate to the field.
+    pub path: Vec<FieldPathSegment>,
+}
+
+/// A segment in a field path.
+#[derive(Clone, Debug)]
+pub enum FieldPathSegment {
+    /// Named struct field: e.g., "translation"
+    Named(String),
+    /// Indexed tuple/array field: e.g., 0, 1, 2
+    Index(usize),
+}

--- a/src/gui/widgets/reflected.rs
+++ b/src/gui/widgets/reflected.rs
@@ -1,0 +1,143 @@
+use bevy::prelude::*;
+use bevy::ui::Val::*;
+use crate::gui::config::InspectorConfig;
+
+use super::{FieldPath, FieldPathSegment};
+use super::drag_value::{DragValue, DragValueDragState};
+
+/// Trait to construct a reflector widget from a concrete type
+/// This is a convenience trait to enable using a &Self input
+/// 
+/// This trait is used to automatically drive the [`PartialReflectWidget`] used in the broader case
+/// that the value may be a partially reflected dynamic type
+pub trait ReflectWidget: Reflect + Sized {
+    /// Construct a widget bundle with a reference to [`Self`] and the path to the field containing self
+    /// This bundle will be added to an otherwise empty entity serving as the container for this widget
+    fn widget(&self, field_path: &FieldPath, config: &InspectorConfig) -> impl Bundle;
+}
+
+/// Trait to construct a reflector widget from any PartialReflect type
+/// Implement this trait directly if you need to use it
+/// for example if your type doesn't support cloning or full reflection
+/// 
+/// usually you can rely on the simpler [`ReflectWidget`] implementing it for you
+pub trait PartialReflectWidget: PartialReflect + Sized {
+    /// Try to construct a bundle with a potentially dynamic object.
+    /// this can fail, for example if this expects the type to be fully reflected but it as not
+    fn try_widget(
+        self_: &dyn PartialReflect,
+        field_path: &FieldPath,
+        config: &InspectorConfig,
+    ) -> Option<impl Bundle>;
+}
+
+impl<T: ReflectWidget> PartialReflectWidget for T {
+    /// Try using the concrete type's [`ReflectWidget`] implementation
+    fn try_widget(
+        self_: &dyn PartialReflect,
+        field_path: &FieldPath,
+        config: &InspectorConfig,
+    ) -> Option<impl Bundle> {
+        self_
+            .try_downcast_ref::<Self>()
+            .map(|self_| ReflectWidget::widget(self_, field_path, config))
+    }
+}
+
+impl PartialReflectWidget for Vec3 {
+    fn try_widget(
+        self_: &dyn PartialReflect,
+        field_path: &FieldPath,
+        config: &InspectorConfig,
+    ) -> Option<impl Bundle> {
+        let self_ = self_.reflect_ref().as_struct().ok()?;
+        let x = *self_.field_at(0)?.try_downcast_ref::<f32>()?;
+        let y = *self_.field_at(1)?.try_downcast_ref::<f32>()?;
+        let z = *self_.field_at(2)?.try_downcast_ref::<f32>()?;
+        let field_path = field_path.clone();
+        let small_font_size = config.small_font_size;
+
+        Some((
+            Node {
+                min_width: Px(60.0),
+                padding: UiRect::horizontal(Px(4.0)),
+                border: UiRect::all(Px(1.0)),
+                ..default()
+            },
+            Children::spawn(SpawnIter(
+                [
+                    ("x", x, Color::srgba(1., 0.5, 0.5, 1.)),
+                    ("y", y, Color::srgba(0.5, 1., 0.5, 1.)),
+                    ("z", z, Color::srgba(0.5, 0.5, 1., 1.)),
+                ]
+                .into_iter()
+                .map(move |(field, val, color)| {
+                    let mut field_path = field_path.clone();
+                    field_path
+                        .path
+                        .push(FieldPathSegment::Named(field.to_owned()));
+                    (
+                        Node {
+                            min_width: Px(60.0),
+                            padding: UiRect::horizontal(Px(4.0)),
+                            border: UiRect::all(Px(1.0)),
+                            ..default()
+                        },
+                        BorderColor::all(Color::srgba(0.3, 0.3, 0.3, 1.0)),
+                        BackgroundColor(Color::srgba(0.15, 0.15, 0.15, 1.0)),
+                        DragValue {
+                            field_path,
+                            drag_speed: 0.1,
+                            precision: 2,
+                            min: None,
+                            max: None,
+                        },
+                        DragValueDragState::default(),
+                        Interaction::default(),
+                        Children::spawn_one((
+                            Text::new(format!("{:.2}", val)),
+                            TextFont {
+                                font_size: FontSize::Px(small_font_size),
+                                ..default()
+                            },
+                            TextColor(color), // x y z tinted
+                        )),
+                    )
+                }),
+            )),
+        ))
+    }
+}
+
+impl ReflectWidget for f32 {
+    fn widget(&self, field_path: &FieldPath, config: &InspectorConfig) -> impl Bundle {
+        let val = *self;
+        (
+            Node {
+                min_width: Px(60.0),
+                padding: UiRect::horizontal(Px(4.0)),
+                border: UiRect::all(Px(1.0)),
+                ..default()
+            },
+            BorderColor::all(Color::srgba(0.3, 0.3, 0.3, 1.0)),
+            BackgroundColor(Color::srgba(0.15, 0.15, 0.15, 1.0)),
+            DragValue {
+                field_path: field_path.clone(),
+                drag_speed: 0.1,
+                precision: 2,
+                min: None,
+                max: None,
+            },
+            DragValueDragState::default(),
+            Interaction::default(),
+            Children::spawn_one((
+                Text::new(format!("{:.2}", val)),
+                TextFont {
+                    font_size: FontSize::Px(config.small_font_size),
+                    ..default()
+                },
+                TextColor(Color::srgba(0.9, 0.9, 0.6, 1.0)),
+            )),
+        )
+    }
+}

--- a/src/gui/widgets/registry.rs
+++ b/src/gui/widgets/registry.rs
@@ -1,0 +1,127 @@
+use bevy::prelude::*;
+use bevy::reflect::enums::Enum;
+use bevy::ui::Val::*;
+use bevy::{
+    feathers::{
+        theme::{ThemeFontColor, ThemedText},
+        tokens,
+    },
+    platform::collections::HashMap,
+};
+use core::any::TypeId;
+
+use crate::gui::{config::InspectorConfig, widgets::FieldPath};
+
+use super::reflected::PartialReflectWidget;
+
+/// Type-erasing function that places a widget [`Bundle`] into an empty entity
+pub struct WidgetBuilder(Box<dyn FnOnce(&mut EntityWorldMut<'_>) + 'static>);
+
+impl WidgetBuilder {
+    pub fn new<B: Bundle>(widget: B) -> Self {
+        Self(Box::new(move |entity: &'_ mut EntityWorldMut<'_>| {
+            entity.insert(widget);
+        }))
+    }
+
+    pub fn apply_widget(self, entity: &mut EntityWorldMut<'_>) {
+        self.0(entity)
+    }
+}
+
+/// Type-erasing function that initializes the [`Bundle`] for a given widget
+type WidgetCreator = Box<
+    dyn Fn(&dyn PartialReflect, &FieldPath, &InspectorConfig) -> Option<WidgetBuilder>
+        + Sync
+        + Send
+        + 'static,
+>;
+
+/// Registry storing the widget implementations for types
+#[derive(Resource, Default)]
+pub struct WidgetRegistry {
+    builders: HashMap<TypeId, WidgetCreator>,
+}
+
+impl WidgetRegistry {
+    pub fn with<T: PartialReflectWidget>(mut self) -> Self {
+        self.add::<T>();
+        self
+    }
+
+    /// Register a type that implements a widget
+    pub fn add<T: PartialReflectWidget>(&mut self) {
+        self.builders
+            .insert(TypeId::of::<T>(), Box::new(Self::builder_for::<T>));
+    }
+
+    /// Register or override a type with a widget and bypass the [`PartialReflectWidget`] trait
+    pub fn add_custom<T: Reflect>(&mut self, builder: WidgetCreator) {
+        self.builders
+            .insert(TypeId::of::<T>(), builder);
+    }
+
+    /// get a widget builder for this type if is registered
+    pub fn get_widget(
+        &self,
+        t: &dyn PartialReflect,
+        field_path: &FieldPath,
+        config: &InspectorConfig,
+    ) -> Option<WidgetBuilder> {
+        let type_id = t.get_represented_type_info().map(|info| info.type_id());
+        type_id
+            .and_then(|type_id| self.builders.get(&type_id))
+            .and_then(|b| b(t, field_path, config))
+    }
+
+    /// get a label pseudo-widget
+    pub fn label_widget(&self, label: String, config: &InspectorConfig) -> WidgetBuilder {
+        WidgetBuilder::new((
+            Text::new(label),
+            TextFont {
+                font_size: FontSize::Px(config.small_font_size),
+                ..default()
+            },
+            ThemeFontColor(tokens::TEXT_DIM),
+            ThemedText,
+            TextColor(config.muted_text_color),
+        ))
+    }
+
+    /// get an enum variant widget for this type
+    /// todo: mutation of the variant with this widget
+    pub fn enum_widget(
+        &self,
+        type_name: &str,
+        t: &dyn Enum,
+        config: &InspectorConfig,
+    ) -> WidgetBuilder {
+        WidgetBuilder::new((
+            Node {
+                min_width: Px(60.0),
+                padding: UiRect::horizontal(Px(4.0)),
+                border: UiRect::all(Px(1.0)),
+                ..default()
+            },
+            BorderColor::all(Color::srgba(0.3, 0.3, 0.3, 1.0)),
+            BackgroundColor(Color::srgba(0.15, 0.15, 0.15, 1.0)),
+            Children::spawn_one((
+                Text::new(format!("{type_name}::{}", t.variant_name())),
+                TextFont {
+                    font_size: FontSize::Px(config.small_font_size),
+                    ..default()
+                },
+            )),
+        ))
+    }
+
+    /// function enclosing the creation of a builder 
+    fn builder_for<T: PartialReflectWidget>(
+        t: &dyn PartialReflect,
+        field_path: &FieldPath,
+        config: &InspectorConfig,
+    ) -> Option<WidgetBuilder> {
+        let widget = <T as PartialReflectWidget>::try_widget(t, field_path, config)?;
+        Some(WidgetBuilder::new(widget))
+    }
+}

--- a/src/reflection_tools.rs
+++ b/src/reflection_tools.rs
@@ -310,25 +310,28 @@ pub fn is_dynamic_safe(val: &dyn PartialReflect) -> bool {
     }
 }
 
-/// Safely clones a [`PartialReflect`] value into a boxed dynamic representation.
+/// Safely clones a [`PartialReflect`] value into a box.
 ///
-/// This handles the distinction between "dynamic-safe" types (which can use `.to_dynamic()`)
-/// and opaque/unsafe types (which must use `.reflect_clone()`).
+/// This handles the distinction between types that can be cloned directly
+/// and those that need to be converted to a dynamic type
 pub fn clone_partial_reflect(reflected: &dyn PartialReflect) -> Option<Box<dyn PartialReflect>> {
-    if is_dynamic_safe(reflected) {
-        match reflected.reflect_ref() {
-            bevy::reflect::ReflectRef::Opaque(value) => value
-                .reflect_clone()
-                .ok()
-                .map(|boxed| boxed.into_partial_reflect()),
-            _ => Some(reflected.to_dynamic()),
-        }
-    } else {
-        reflected
-            .reflect_clone()
-            .ok()
-            .map(|boxed| boxed.into_partial_reflect())
-    }
+    reflected
+        .reflect_clone()
+        .ok()
+        .map(|boxed| boxed.into_partial_reflect())
+        .or_else(|| {
+            if is_dynamic_safe(reflected) {
+                match reflected.reflect_ref() {
+                    bevy::reflect::ReflectRef::Opaque(value) => value
+                        .reflect_clone()
+                        .ok()
+                        .map(|boxed| boxed.into_partial_reflect()),
+                    _ => Some(reflected.to_dynamic()),
+                }
+            } else {
+                None
+            }
+        })
 }
 
 /// Converts a reflected value to a string for debugging purposes.


### PR DESCRIPTION
Here is our design proposal for a solution to allow more complex component displays in the component list.
It implements a `WidgetRegistry` to associate a `Reflect` or `PartialReflect` type with a Bundle builder. Builders are created by `extract_fields_from_reflect` then applied to entities in the components panel.
(this process is to do with type-erasure)
It adds an example of a widget for the Vec3 type which you can see in the screenshot.

The existing `clone_partial_reflect` implementation prioritizes dynamic cloning, but we do think `reflect_clone` should be tried first as it preserves full reflection for supported types.

It's based around this trait:
```rs
pub trait ReflectWidget: Reflect {
    fn widget(&self, field_path: &FieldPath, config: &InspectorConfig) -> impl Bundle;
}
```
It's a convenient api for defining custom editor widgets for any type.

<img width="1105" height="823" alt="Screenshot of the editor, the components window showing colored widgets for the vec3" src="https://github.com/user-attachments/assets/63096110-42ae-4030-ada3-5cf121cae92b" />
